### PR TITLE
Statewide Candidate Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Go to http://localhost:3010 in your favorite browser. If everything's working co
 
 ## Post-Setup
 
-At least once, you should load the database with valid zip codes and metro areas. The import files are not in the repo, they're too large. Ask a colleague for these files:
+At least once, you should load the database with valid zip codes and metro areas. The import files are not in the repo, they're too large. They're located in Google Drive:
 
-* `postal-codes.csv`
-* `msa.txt`
+* `postal-codes.csv`: https://drive.google.com/open?id=1vfwSF3bwX2GnM7fLq3iktgR7CDIhaPsI
+* `msa.txt`: https://drive.google.com/open?id=16oM_ZJXogOBtz9U6MDEaZXzW6fn4AMog
 
 Copy them to the `tmp`, then:
 

--- a/app/models/metro.rb
+++ b/app/models/metro.rb
@@ -29,4 +29,11 @@ class Metro < ApplicationRecord
       create attributes
     end
   end
+  
+  def states
+    city, state_list = name.split(/,\s*/)
+    return [] if state_list.nil?
+    
+    state_list.split('-')
+  end
 end

--- a/app/models/metro.rb
+++ b/app/models/metro.rb
@@ -4,6 +4,9 @@ class Metro < ApplicationRecord
 
   validates :code, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: true
+  
+  scope :city, ->{ where.not(source: 'ST') }
+  scope :state, ->{ where(source: 'ST') }
 
   class << self
     def load_txt filename
@@ -22,8 +25,10 @@ class Metro < ApplicationRecord
         
         code = fields[0].strip
         name = fields[1].strip.gsub(/,\s*/, ', ')
+        source = fields[2].strip
+        state = name.split(', ')[1]
         
-        attributes << {code: code, name: name}
+        attributes << {code: code, name: name, source: source, state: state}
       end
         
       create attributes

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -74,13 +74,19 @@ class Opportunity < ApplicationRecord
     end
     
     state_ids = state_ids_for_metro_ids(selected_ids)
+    city_ids = metro_ids_for_state_ids(selected_ids)
     
-    FellowMetro.fellow_ids_for(selected_ids + state_ids)
+    FellowMetro.fellow_ids_for(selected_ids + state_ids + city_ids)
   end
   
   def state_ids_for_metro_ids metro_ids
-    state_abbrs = Metro.where(id: metro_ids).map(&:states).flatten.uniq
+    state_abbrs = Metro.city.where(id: metro_ids).map(&:states).flatten.uniq
     Metro.where(code: state_abbrs).pluck(:id)
+  end
+  
+  def metro_ids_for_state_ids metro_ids
+    state_abbrs = Metro.state.where(id: metro_ids).pluck(:code)
+    Metro.city.reject{|c| (c.states & state_abbrs).empty?}.map(&:id)
   end
   
   def candidate_ids= candidate_id_list

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -73,7 +73,14 @@ class Opportunity < ApplicationRecord
       metro_ids
     end
     
-    FellowMetro.fellow_ids_for(selected_ids)
+    state_ids = state_ids_for_metro_ids(selected_ids)
+    
+    FellowMetro.fellow_ids_for(selected_ids + state_ids)
+  end
+  
+  def state_ids_for_metro_ids metro_ids
+    state_abbrs = Metro.where(id: metro_ids).map(&:states).flatten.uniq
+    Metro.where(code: state_abbrs).pluck(:id)
   end
   
   def candidate_ids= candidate_id_list

--- a/app/views/candidates/index.html.erb
+++ b/app/views/candidates/index.html.erb
@@ -19,7 +19,7 @@
   </div-->
 
   <div id="metro-tags" class="floating-search jquery-tags" style="float: left;">
-    <h3>Metro Areas</h3>
+    <h3>Locations</h3>
     <%= text_area_tag :opportunity_metro_tags, params[:search][:metros], name: "search[metros]", class: 'auto-refresh' %>
   </div>
 <% end %>
@@ -37,7 +37,7 @@
         <th>Efficacy</th>
         <th>Interests</th>
         <th>Industries</th>
-        <th>Metro Areas</th>
+        <th>Locations</th>
         <th>Distance</th>
         <th>Status</th>
       

--- a/app/views/employers/_form.html.erb
+++ b/app/views/employers/_form.html.erb
@@ -20,10 +20,7 @@
 
   <div id="industry-tags" class="jquery-tags">
     <%= form.text_area :industry_tags %>
-    <%= link_to 'see full list', '#', id: 'industry-full-list' %>
   </div>
-  
-  <%= render 'industries/check_boxes', object: @employer %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/fellows/_form.html.erb
+++ b/app/views/fellows/_form.html.erb
@@ -103,10 +103,7 @@
   
   <div id="metro-tags" class="jquery-tags">
     <%= form.text_area :metro_tags %>
-    <%= link_to 'see full list', '#', id: 'metro-full-list' %>
   </div>
-
-  <%= render 'metros/check_boxes', object: fellow %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/fellows/_form.html.erb
+++ b/app/views/fellows/_form.html.erb
@@ -85,19 +85,13 @@
 
   <div id="industry-tags" class="jquery-tags">
     <%= form.text_area :industry_tags %>
-    <%= link_to 'see full list', '#', id: 'industry-full-list' %>
   </div>
-
-  <%= render 'industries/check_boxes', object: fellow %>
 
   <h3>Interests</h3>
   
   <div id="interest-tags" class="jquery-tags">
     <%= form.text_area :interest_tags %>
-    <%= link_to 'see full list', '#', id: 'interest-full-list' %>
   </div>
-
-  <%= render 'interests/check_boxes', object: fellow %>
   
   <h3>Metro Areas</h3>
   

--- a/app/views/opportunities/_form.html.erb
+++ b/app/views/opportunities/_form.html.erb
@@ -66,28 +66,22 @@
 
   <div id="industry-tags" class="jquery-tags">
     <%= form.text_area :industry_tags %>
-    <%= link_to 'see full list', '#', id: 'industry-full-list' %>
+    <!--%= link_to 'see full list', '#', id: 'industry-full-list' %-->
   </div>
 
-  <%= render 'industries/check_boxes', object: opportunity %>
+  <!--%= render 'industries/check_boxes', object: opportunity %-->
 
   <h3>Interests</h3>
   
   <div id="interest-tags" class="jquery-tags">
     <%= form.text_area :interest_tags %>
-    <%= link_to 'see full list', '#', id: 'interest-full-list' %>
   </div>
-
-  <%= render 'interests/check_boxes', object: opportunity %>
   
   <h3>Metro Areas</h3>
   
   <div id="metro-tags" class="jquery-tags">
     <%= form.text_area :metro_tags %>
-    <%= link_to 'see full list', '#', id: 'metro-full-list' %>
   </div>
-
-  <%= render 'metros/check_boxes', object: opportunity %>
   
   <div class="actions">
     <%= form.submit %>

--- a/db/migrate/20180621223924_add_metro_source_to_metros.rb
+++ b/db/migrate/20180621223924_add_metro_source_to_metros.rb
@@ -1,0 +1,6 @@
+class AddMetroSourceToMetros < ActiveRecord::Migration[5.2]
+  def change
+    add_column :metros, :source, :string
+    add_index :metros, :source
+  end
+end

--- a/db/migrate/20180621224507_add_state_to_metros.rb
+++ b/db/migrate/20180621224507_add_state_to_metros.rb
@@ -1,0 +1,6 @@
+class AddStateToMetros < ActiveRecord::Migration[5.2]
+  def change
+    add_column :metros, :state, :string
+    add_index :metros, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_21_153344) do
+ActiveRecord::Schema.define(version: 2018_06_21_224507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -235,8 +235,12 @@ ActiveRecord::Schema.define(version: 2018_06_21_153344) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "source"
+    t.string "state"
     t.index ["code"], name: "index_metros_on_code", unique: true
     t.index ["name"], name: "index_metros_on_name", unique: true
+    t.index ["source"], name: "index_metros_on_source"
+    t.index ["state"], name: "index_metros_on_state"
   end
 
   create_table "metros_opportunities", id: false, force: :cascade do |t|

--- a/spec/models/metro_spec.rb
+++ b/spec/models/metro_spec.rb
@@ -42,4 +42,33 @@ RSpec.describe Metro, type: :model do
       expect(Metro.count).to eq(5)
     end
   end
+  
+  ##################
+  # Instance methods
+  ##################
+
+  describe '#states' do
+    it "returns empty when states aren't supplied" do
+      metro = Metro.new name: 'Lincoln'
+      expect(metro.states).to eq([])
+    end
+    
+    it "returns the states with city,state formatted name" do
+      metro = Metro.new name: 'Lincoln,NE'
+      expect(metro.states).to eq(['NE'])
+    end
+    
+    it "returns the states with 'city, state' format" do
+      metro = Metro.new name: 'Lincoln, NE'
+      expect(metro.states).to eq(['NE'])
+    end
+    
+    it "returns the states when there are more than one" do
+      metro = Metro.new name: 'Omaha,NE-IA'
+      
+      expect(metro.states.size).to eq(2)
+      expect(metro.states).to include('NE')
+      expect(metro.states).to include('IA')
+    end
+  end
 end

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -108,6 +108,35 @@ RSpec.describe Opportunity, type: :model do
     end
   end
   
+  describe "#state_ids_for_metro_ids" do
+    it "returns associated metro ids by state" do
+      opportunity = build :opportunity
+      
+      lincoln = create :metro, code: '1001', name: 'Lincoln, NE'
+      nebraska = create :metro, code: 'NE'
+      fellow_ne = create :fellow
+      fellow_ne.metros << nebraska
+    
+      aimes = create :metro, code: '1002', name: 'Aimes, IA'
+      iowa = create :metro, code: 'IA'
+      fellow_ia = create :fellow
+      fellow_ia.metros << iowa
+
+      lenexa = create :metro, code: '1003', name: 'Lenexa, KS'
+      kansas = create :metro, code: 'KS'
+      fellow_ks = create :fellow
+      fellow_ks.metros << kansas
+    
+      state_ids = opportunity.state_ids_for_metro_ids([lincoln.id, aimes.id])
+    
+      expect(state_ids).to be_an(Array)
+      expect(state_ids.size).to eq(2)
+      expect(state_ids).to include(nebraska.id)
+      expect(state_ids).to include(iowa.id)
+      expect(state_ids).to_not include(kansas.id)
+    end
+  end
+  
   describe '#candidate_ids=' do
     it "creates fellow_opportunities" do
       fellow = create :fellow

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -112,18 +112,18 @@ RSpec.describe Opportunity, type: :model do
     it "returns associated metro ids by state" do
       opportunity = build :opportunity
       
-      lincoln = create :metro, code: '1001', name: 'Lincoln, NE'
-      nebraska = create :metro, code: 'NE'
+      lincoln = create :metro, code: '1001', name: 'Lincoln, NE', state: 'NE', source: 'MSA'
+      nebraska = create :metro, code: 'NE', source: 'ST'
       fellow_ne = create :fellow
       fellow_ne.metros << nebraska
     
-      aimes = create :metro, code: '1002', name: 'Aimes, IA'
-      iowa = create :metro, code: 'IA'
+      aimes = create :metro, code: '1002', name: 'Aimes, IA', state: 'IA', source: 'MSA'
+      iowa = create :metro, code: 'IA', source: 'ST'
       fellow_ia = create :fellow
       fellow_ia.metros << iowa
 
-      lenexa = create :metro, code: '1003', name: 'Lenexa, KS'
-      kansas = create :metro, code: 'KS'
+      lenexa = create :metro, code: '1003', name: 'Lenexa, KS', state: 'KS', source: 'MSA'
+      kansas = create :metro, code: 'KS', source: 'ST'
       fellow_ks = create :fellow
       fellow_ks.metros << kansas
     


### PR DESCRIPTION
Candidate searches can now be performed on a statewide basis, thanks to three changes:

* states are now included as "metro areas", though we may want to rename this if people complain.
* when admin searches for a city (ie, "Lincoln, NE") they will also find candidates who are tagged with that state (ie, "Nebraska").
* when admin searches for a state (ie, "Nebraska") they will find any candidates tagged with any metro areas in that state (ie, "Lincoln" or "Omaha").

This is necessary because almost 40% of US zip codes don't "belong" to a metro area. In Nebraska, for example, the eastern 10% of the state has two metro areas, and the western 90% has ZERO. People in central/western Nebraska would likely look for opportunities in Nebraska as a whole, not specifically in Lincoln or Omaha.

Here's the screencap:
https://drive.google.com/open?id=1tGyjdNrNKwxcEQ0Uz12NmGFA7fQTVE7e

**Search Far and Wide!**
![search-far-and-wide](https://user-images.githubusercontent.com/12893/41750994-92b65cb2-7584-11e8-8faa-ed759d51679a.gif)
