### PR TITLE
Temporary Default Fellow Location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'capybara', '~> 2.18'
   gem 'selenium-webdriver', '~> 3.7'
   gem 'database_cleaner'
+  gem 'dotenv'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,6 @@ gem 'bulk_insert'
 
 gem 'will_paginate'
 gem 'delayed_job_active_record'
+
+gem 'devise'
+gem 'devise_cas_authenticatable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       devise (>= 1.2.0)
       rubycas-client (>= 2.2.1)
     diff-lcs (1.3)
+    dotenv (2.5.0)
     erubi (1.7.1)
     execjs (2.7.0)
     factory_bot (4.8.2)
@@ -300,6 +301,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise
   devise_cas_authenticatable
+  dotenv
   factory_bot_rails
   guard-rspec
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    bcrypt (3.1.12)
     bindex (0.5.0)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
@@ -85,6 +86,15 @@ GEM
     delayed_job_active_record (4.1.3)
       activerecord (>= 3.0, < 5.3)
       delayed_job (>= 3.0, < 5)
+    devise (4.4.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0, < 6.0)
+      responders
+      warden (~> 1.2.3)
+    devise_cas_authenticatable (1.10.3)
+      devise (>= 1.2.0)
+      rubycas-client (>= 2.2.1)
     diff-lcs (1.3)
     erubi (1.7.1)
     execjs (2.7.0)
@@ -152,6 +162,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    orm_adapter (0.5.0)
     paranoia (2.4.1)
       activerecord (>= 4.0, < 5.3)
     pg (1.0.0)
@@ -192,6 +203,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -214,6 +228,8 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
+    rubycas-client (2.3.9)
+      activesupport
     rubyzip (1.2.1)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
@@ -256,6 +272,8 @@ GEM
       tzinfo (>= 1.0.0)
     uglifier (4.1.10)
       execjs (>= 0.3.0, < 3)
+    warden (1.2.7)
+      rack (>= 1.0)
     web-console (3.6.2)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -280,6 +298,8 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   delayed_job_active_record
+  devise
+  devise_cas_authenticatable
   factory_bot_rails
   guard-rspec
   jbuilder (~> 2.5)

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -27,6 +27,8 @@ class Cohort < ApplicationRecord
           })
         end
 
+        fellow.metros << fellow.default_metro if fellow.default_metro
+
         proxy_association.owner.cohort_fellows.find_or_create_by(fellow_id: fellow.id).update(cohort_fellow_attributes)
       rescue ActiveRecord::RecordInvalid
         return nil

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -37,6 +37,7 @@ class Fellow < ApplicationRecord
           last_name: data['Last Name'],
           phone: data['Phone'],
           email: data['Email'],
+          postal_code: cohort.course.site.location.contact.postal_code,
           graduation_year: data['Ant. Grad Year'],
           graduation_semester: data['Ant. Grad Semester'],
           graduation_fiscal_year: 2000 + data['Grad FY'][2..4].to_i,
@@ -107,7 +108,11 @@ class Fellow < ApplicationRecord
     return nil unless contact && contact.postal_code
     
     @distance_from ||= {}
-    @distance_from[postal_code] = PostalCode.distance(contact.postal_code, postal_code)
+    @distance_from[postal_code] = PostalCode.distance(assumed_postal_code, postal_code)
+  end
+  
+  def assumed_postal_code
+    contact.postal_code || cohort.course.site.location.contact.postal_code
   end
   
   def industry_tags

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,41 @@
+# Monkey-patch the CAS gem so we can use it without losing the database
+# features we use for SSO - we still manage the users here, including
+# their passwords in this database, but we want to use the CAS server
+# for typical user login so it is seamless with Canvas.
+#
+# As a result, we do want database_authenticatable, and it is nice to keep
+# its routes as a fallback. We just ALSO want cas_authenticatable and would
+# prefer to use its routes in the views when we can.
+#
+# Without this, database_authenticatable and cas_authenticatable are incompatible
+# because they both try to define user_sign_in_path, etc.
+
+ActionDispatch::Routing::Mapper.class_eval do
+  # This code is copy/pasted from the devise_cas_authenticatable gem's source code,
+  # then modified to fit our interoperability requirements and rubocop's whining.
+
+  # The main change is the path names are suffixed with '_sso' now.
+
+  protected
+
+  def devise_cas_authenticatable(mapping, controllers)
+    sign_out_via = (Devise.respond_to?(:sign_out_via) && Devise.sign_out_via) || [:get, :post]
+
+    # service endpoint for CAS server
+    get 'service', :to => "#{controllers[:cas_sessions]}#service", :as => 'service'
+    post 'service', :to => "#{controllers[:cas_sessions]}#single_sign_out", :as => 'single_sign_out'
+
+    resource :session, :only => [], :controller => controllers[:cas_sessions], :path => '' do
+      get :new, :path => mapping.path_names[:sign_in_sso], :as => 'new_sso'
+      get :unregistered
+      post :create, :path => mapping.path_names[:sign_in_sso]
+      match :destroy, :path => mapping.path_names[:sign_out_sso], :as => 'destroy_sso', :via => sign_out_via
+    end
+  end
+end
+
+# With that fixed, we can now define the regular User class.
+class User < ApplicationRecord
+  devise :database_authenticatable, :cas_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable, :confirmable
+end

--- a/app/views/coaches/index.html.erb
+++ b/app/views/coaches/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Coaches</h1>
 
 <table>

--- a/app/views/coaches/show.html.erb
+++ b/app/views/coaches/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Name:</strong>
   <%= @coach.name %>

--- a/app/views/cohort_fellows/index.html.erb
+++ b/app/views/cohort_fellows/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Cohort Fellows</h1>
 
 <table>

--- a/app/views/cohort_fellows/show.html.erb
+++ b/app/views/cohort_fellows/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Grade:</strong>
   <%= @cohort_fellow.grade %>

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Cohorts</h1>
 
 <table>

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Name:</strong>
   <%= @cohort.name %>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Contacts</h1>
 
 <table>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Address 1:</strong>
   <%= @contact.address_1 %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Site:</strong>
   <%= @course.site.name %>

--- a/app/views/employers/index.html.erb
+++ b/app/views/employers/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Employers</h1>
 
 <table class="action-list employers">

--- a/app/views/employers/show.html.erb
+++ b/app/views/employers/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1><%= @employer.name %></h1>
 
 <h2>Industries</h2>

--- a/app/views/employment_statuses/index.html.erb
+++ b/app/views/employment_statuses/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Employment Statuses</h1>
 
 <table>

--- a/app/views/employment_statuses/show.html.erb
+++ b/app/views/employment_statuses/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Name:</strong>
   <%= @employment_status.name %>

--- a/app/views/fellow_opportunities/index.html.erb
+++ b/app/views/fellow_opportunities/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Fellow Opportunities</h1>
 
 <table>

--- a/app/views/fellow_opportunities/show.html.erb
+++ b/app/views/fellow_opportunities/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Secured on:</strong>
   <%= @fellow_opportunity.secured_on %>

--- a/app/views/fellows/index.html.erb
+++ b/app/views/fellows/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Fellows</h1>
 
 <table class="fellows">

--- a/app/views/fellows/show.html.erb
+++ b/app/views/fellows/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>Fellow Info:</p>
 <h1><%= @fellow.first_name %> <%= @fellow.last_name %></h1>
 

--- a/app/views/fellows/upload.html.erb
+++ b/app/views/fellows/upload.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Import Fellows</h1>
 
 <p>Upload a CSV export of the PAF Master Roster to import/update fellow records.</p>

--- a/app/views/home/welcome.html.erb
+++ b/app/views/home/welcome.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <%= link_to 'Add New Opportunity', new_opportunity_path, class: "button" %>
 <ul>
   <li><%= link_to "Employers", employers_path %> (<%= Employer.count %>)</li>

--- a/app/views/industries/index.html.erb
+++ b/app/views/industries/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Industries</h1>
 
 <table>

--- a/app/views/industries/show.html.erb
+++ b/app/views/industries/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Name:</strong>
   <%= @industry.name %>

--- a/app/views/interests/index.html.erb
+++ b/app/views/interests/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Interests</h1>
 
 <table>

--- a/app/views/interests/show.html.erb
+++ b/app/views/interests/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Name:</strong>
   <%= @interest.name %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,9 @@
       <h1><%= link_to 'My Career Manager Admin', root_path %></h1>
     </header>
     <main>
+      <p id="notice"><%= notice %></p>
+      <p id="alert"><%= alert %></p>
+      
       <%= yield %>
     </main>
   </body>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Locations</h1>
 
 <table>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Name:</strong>
   <%= @location.name %>

--- a/app/views/opportunities/index.html.erb
+++ b/app/views/opportunities/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1><%= @employer ? "#{@employer.name} " : '' %>Opportunities</h1>
 
 <%= render "opportunities/list", opportunities: @opportunities %>

--- a/app/views/opportunities/show.html.erb
+++ b/app/views/opportunities/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Opportunity Name:</strong>
   <%= @opportunity.name %>

--- a/app/views/opportunity_stages/index.html.erb
+++ b/app/views/opportunity_stages/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Opportunity Stages</h1>
 
 <table>

--- a/app/views/opportunity_stages/show.html.erb
+++ b/app/views/opportunity_stages/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Name:</strong>
   <%= @opportunity_stage.name %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Sites</h1>
 
 <table>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1><%= @site.name %></h1>
 
 <h2>Courses</h2>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Tasks</h1>
 
 <table>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1><%= @task.opportunity.name %>: <%= @task.name %></h1>
 
 <p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,8 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  
+  config.action_mailer.default_url_options = {host: 'localhost', port: 3010}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = {host: 'mcmanager.herokuapp.com'}
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = {host: 'localhost', port: 3011}
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = 'd7d9151e6ba533e484e5e9e5ec794131b01ef6f14cc567fd45ca1a78966ec6cc5bd1d7ee0b645f1a01ae041dcc8d2274604b6335df9a46f6dcc6b7b31dadb6ec'
+  
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 11
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'fa9ae20ab6f1e017fddbb9944d3075fb24585259ab984c38d6a106e5bb42e6aae29697d5a98c720a7157c14c706d22cb219d4ac53937852f1531102ffb509220'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = 'd7d9151e6ba533e484e5e9e5ec794131b01ef6f14cc567fd45ca1a78966ec6cc5bd1d7ee0b645f1a01ae041dcc8d2274604b6335df9a46f6dcc6b7b31dadb6ec'
+  # config.secret_key = Rails.application.secrets.devise_secret_key
   
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -18,13 +18,20 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = '"Braven" <' + Rails.application.secrets.mailer_from_email + '>'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ActionMailer::Base'
+  
+  # ==> CAS configuration
+  config.cas_base_url = Rails.application.secrets.sso_url
+  config.cas_create_user = false
+  config.cas_enable_single_sign_out = true
+
+  config.cas_username_column = 'email'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
@@ -114,7 +121,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = 'fa9ae20ab6f1e017fddbb9944d3075fb24585259ab984c38d6a106e5bb42e6aae29697d5a98c720a7157c14c706d22cb219d4ac53937852f1531102ffb509220'
+  config.pepper = Rails.application.secrets.devise_pepper
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false
@@ -163,7 +170,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 4..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
@@ -173,7 +180,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 24.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,64 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :users
   get 'home/welcome'
   get 'home/new_opportunity', as: 'new_opportunity'
   

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,165 @@
+development:
+  smtp_server: <%= ENV['SMTP_SERVER'] %>
+  smtp_username: <%= ENV['SMTP_USERNAME'] %>
+  smtp_password: <%= ENV['SMTP_PASSWORD'] %>
+  smtp_domain: <%= ENV['SMTP_DOMAIN'] %>
+  root_domain: <%= ENV['ROOT_DOMAIN'] %>
+  mailer_from_email: <%= ENV['MAILER_FROM_EMAIL'] %>
+  # No emails are actually sent from the test server, but
+  # it does need a to email lest it throws "invalid smtp email" exceptions
+  smtp_override_recipient: <%= ENV['SMTP_OVERRIDE_RECIPIENT'] %>
+  aws_bucket: <%= ENV['AWS_BUCKET'] %>
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
+  devise_secret_key: <%= ENV['DEVISE_SECRET_KEY'] %>
+  google_analytics_account: <%= ENV['GOOGLE_ANALYTICS_ACCOUNT'] %>
+  staff_email: <%= ENV['STAFF_NOTIFICATION_EMAIL'] %>
+  canvas_access_token: <%= ENV['CANVAS_ACCESS_TOKEN'] %>
+  canvas_server: <%= ENV['CANVAS_SERVER'] %>
+  canvas_port: <%= ENV['CANVAS_PORT'] %>
+  canvas_use_ssl: <%= ENV['CANVAS_USE_SSL'] %>
+  canvas_allow_self_signed_ssl: <%= ENV['CANVAS_ALLOW_SELF_SIGNED_SSL'] %>
+  sso_url: <%= ENV['SSO_URL'] %>
+  blog_url: <%= ENV['BLOG_URL'] %>
+  salesforce_host: <%= ENV['SALESFORCE_HOST'] %>
+  salesforce_username: <%= ENV['SALESFORCE_USERNAME'] %>
+  salesforce_password: <%= ENV['SALESFORCE_PASSWORD'] %>
+  salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
+  default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
+  salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
+  cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
+  google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
+  google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>
+  google_spreadsheet_refresh_token: <%= ENV['GOOGLE_SPREADSHEET_REFRESH_TOKEN'] %>
+  qa_host: <%= ENV['QA_HOST'] %>
+  qa_token: <%= ENV['QA_TOKEN'] %>
+  mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
+  mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
+  mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
+
+test:
+  smtp_server: <%= ENV['SMTP_SERVER'] %>
+  smtp_username: <%= ENV['SMTP_USERNAME'] %>
+  smtp_password: <%= ENV['SMTP_PASSWORD'] %>
+  smtp_domain: <%= ENV['SMTP_DOMAIN'] %>
+  root_domain: <%= ENV['ROOT_DOMAIN'] %>
+  mailer_from_email: 'test@localhost'
+  # No emails are actually sent from the test server, but
+  # it does need a to email lest it throws "invalid smtp email" exceptions
+  smtp_override_recipient: <%= ENV['SMTP_OVERRIDE_RECIPIENT'] %>
+  aws_bucket: <%= ENV['AWS_BUCKET'] %>
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  devise_pepper: '12312321322'
+  devise_secret_key: '12312312312'
+  google_analytics_account: <%= ENV['GOOGLE_ANALYTICS_ACCOUNT'] %>
+  staff_email: <%= ENV['STAFF_NOTIFICATION_EMAIL'] %>
+  canvas_access_token: <%= ENV['CANVAS_ACCESS_TOKEN'] %>
+  canvas_server: <%= ENV['CANVAS_SERVER'] %>
+  canvas_port: <%= ENV['CANVAS_PORT'] %>
+  canvas_use_ssl: <%= ENV['CANVAS_USE_SSL'] %>
+  canvas_allow_self_signed_ssl: <%= ENV['CANVAS_ALLOW_SELF_SIGNED_SSL'] %>
+  sso_url: <%= ENV['SSO_URL'] %>
+  blog_url: <%= ENV['BLOG_URL'] %>
+  salesforce_host: <%= ENV['SALESFORCE_HOST'] %>
+  salesforce_username: <%= ENV['SALESFORCE_USERNAME'] %>
+  salesforce_password: <%= ENV['SALESFORCE_PASSWORD'] %>
+  salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
+  default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
+  salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
+  cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
+  google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
+  google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>
+  google_spreadsheet_refresh_token: <%= ENV['GOOGLE_SPREADSHEET_REFRESH_TOKEN'] %>
+  qa_host: <%= ENV['QA_HOST'] %>
+  qa_token: <%= ENV['QA_TOKEN'] %>
+  mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
+  mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
+  mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
+
+staging:
+  secret_key_base: <%= ENV['RAILS_SECRET_TOKEN'] %>
+  smtp_server: <%= ENV['SMTP_SERVER'] %>
+  smtp_username: <%= ENV['SMTP_USERNAME'] %>
+  smtp_password: <%= ENV['SMTP_PASSWORD'] %>
+  smtp_domain: <%= ENV['SMTP_DOMAIN'] %>
+  root_domain: <%= ENV['ROOT_DOMAIN'] %>
+  mailer_from_email: <%= ENV['MAILER_FROM_EMAIL'] %>
+  # No emails are actually sent from the test server, but
+  # it does need a to email lest it throws "invalid smtp email" exceptions
+  smtp_override_recipient: <%= ENV['SMTP_OVERRIDE_RECIPIENT'] %>
+  aws_bucket: <%= ENV['AWS_BUCKET'] %>
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
+  devise_secret_key: <%= ENV['DEVISE_SECRET_KEY'] %>
+  google_analytics_account: <%= ENV['GOOGLE_ANALYTICS_ACCOUNT'] %>
+  staff_email: <%= ENV['STAFF_NOTIFICATION_EMAIL'] %>
+  canvas_access_token: <%= ENV['CANVAS_ACCESS_TOKEN'] %>
+  canvas_server: <%= ENV['CANVAS_SERVER'] %>
+  canvas_port: <%= ENV['CANVAS_PORT'] %>
+  canvas_use_ssl: <%= ENV['CANVAS_USE_SSL'] %>
+  canvas_allow_self_signed_ssl: <%= ENV['CANVAS_ALLOW_SELF_SIGNED_SSL'] %>
+  sso_url: <%= ENV['SSO_URL'] %>
+  blog_url: <%= ENV['BLOG_URL'] %>
+  salesforce_host: <%= ENV['SALESFORCE_HOST'] %>
+  salesforce_username: <%= ENV['SALESFORCE_USERNAME'] %>
+  salesforce_password: <%= ENV['SALESFORCE_PASSWORD'] %>
+  salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
+  default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
+  salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
+  cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
+  google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
+  google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>
+  google_spreadsheet_refresh_token: <%= ENV['GOOGLE_SPREADSHEET_REFRESH_TOKEN'] %>
+  qa_host: <%= ENV['QA_HOST'] %>
+  qa_token: <%= ENV['QA_TOKEN'] %>
+  mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
+  mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
+  mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
+
+production:
+  smtp_override_recipient: <%= ENV['SMTP_OVERRIDE_RECIPIENT'] %>
+  smtp_server: <%= ENV['SMTP_SERVER'] %>
+  smtp_username: <%= ENV['SMTP_USERNAME'] %>
+  smtp_password: <%= ENV['SMTP_PASSWORD'] %>
+  smtp_domain: <%= ENV['SMTP_DOMAIN'] %>
+  root_domain: <%= ENV['ROOT_DOMAIN'] %>
+  mailer_from_email: <%= ENV['MAILER_FROM_EMAIL'] %>
+  aws_bucket: <%= ENV['AWS_BUCKET'] %>
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  devise_pepper: <%= ENV['DEVISE_PEPPER'] %>
+  devise_secret_key: <%= ENV['DEVISE_SECRET_KEY'] %>
+  google_analytics_account: <%= ENV['GOOGLE_ANALYTICS_ACCOUNT'] %>
+  staff_email: <%= ENV['STAFF_NOTIFICATION_EMAIL'] %>
+  canvas_access_token: <%= ENV['CANVAS_ACCESS_TOKEN'] %>
+  canvas_server: <%= ENV['CANVAS_SERVER'] %>
+  canvas_port: <%= ENV['CANVAS_PORT'] %>
+  canvas_use_ssl: <%= ENV['CANVAS_USE_SSL'] %>
+  canvas_allow_self_signed_ssl: <%= ENV['CANVAS_ALLOW_SELF_SIGNED_SSL'] %>
+  sso_url: <%= ENV['SSO_URL'] %>
+  blog_url: <%= ENV['BLOG_URL'] %>
+  # Note: the database dot com env vars are NOT here because
+  # they are managed automatically by the gem - the environment variable
+  # needs to be present, but we don't explicitly use it in our code
+  salesforce_host: <%= ENV['SALESFORCE_HOST'] %>
+  salesforce_username: <%= ENV['SALESFORCE_USERNAME'] %>
+  salesforce_password: <%= ENV['SALESFORCE_PASSWORD'] %>
+  salesforce_security_token: <%= ENV['SALESFORCE_SECURITY_TOKEN'] %>
+  default_lead_owner: <%= ENV['DEFAULT_LEAD_OWNER'] %>
+  salesforce_magic_token: <%= ENV['SALESFORCE_MAGIC_TOKEN'] %>
+  calendly_magic_token: <%= ENV['CALENDLY_MAGIC_TOKEN'] %>
+  cookie_domain: <%= ENV['COOKIE_DOMAIN'] %>
+  google_spreadsheet_client_id: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_ID'] %>
+  google_spreadsheet_client_secret: <%= ENV['GOOGLE_SPREADSHEET_CLIENT_SECRET'] %>
+  google_spreadsheet_refresh_token: <%= ENV['GOOGLE_SPREADSHEET_REFRESH_TOKEN'] %>
+  qa_host: <%= ENV['QA_HOST'] %>
+  qa_token: <%= ENV['QA_TOKEN'] %>
+  mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
+  mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
+  mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>

--- a/db/init.rb
+++ b/db/init.rb
@@ -1,3 +1,41 @@
+industries = [
+  'Accounting', 'Advertising', 'Aerospace', 'Banking', 'Beauty / Cosmetics', 'Biotechnology', 'Business', 
+  'Chemical', 'Communications', 'Computer Engineering', 'Computer Hardware', 'Education', 'Electronics', 
+  'Employment / Human Resources', 'Energy', 'Fashion', 'Film', 'Financial Services', 'Fine Arts', 
+  'Food & Beverage', 'Health', 'Information Technology', 'Insurance', 'Journalism / News / Media', 'Law', 
+  'Management / Strategic Consulting', 'Manufacturing', 'Medical Devices & Supplies', 'Performing Arts', 
+  'Pharmaceutical', 'Public Administration', 'Public Relations', 'Publishing', 'Marketing', 'Real Estate', 
+  'Sports', 'Technology', 'Telecommunications', 'Tourism', 'Transportation / Travel', 'Writing'
+]
+    
+industries.sort.each do |name|
+  Industry.find_or_create_by name: name
+end
+
+interests = [
+  'Accounting', 'African American Studies', 'African Studies', 'Agriculture', 'American Indian Studies', 
+  'American Studies', 'Architecture', 'Asian American Studies', 'Asian Studies', 'Dance', 'Visual Arts', 
+  'Theater', 'Music', 'English / Literature', 'Film', 'Foreign Language', 'Graphic Design', 'Philosophy', 
+  'Religion', 'Business', 'Marketing', 'Actuarial Science', 'Hospitality', 'Human Resources', 'Real Estate', 
+  'Health', 'Public Health', 'Medicine', 'Nursing', 'Gender Studies', 'Urban Studies', 'Latin American Studies', 
+  'European Studies', 'Gay and Lesbian Studies', 'Latinx Studies', 'Women’s Studies', 'Education', 'Psychology', 
+  'Child Development', 'Computer Science', 'History', 'Biology', 'Cognitive Science', 'Human Biology', 
+  'Diversity Studies', 'Marine Sciences', 'Maritime Studies', 'Math', 'Nutrition', 'Sports and Fitness', 
+  'Law / Legal Studies', 'Military', 'Public Administration', 'Social Work', 'Criminal Justice', 'Theology', 
+  'Equestrian Studies', 'Food Science', 'Urban Planning', 'Art History', 'Interior Design', 'Landscape Architecture', 
+  'Chemistry', 'Physics', 'Chemical Engineering', 'Software Engineering', 'Industrial Engineering', 
+  'Civil Engineering', 'Electrical Engineering', 'Mechanical Engineering', 'Biomedical Engineering', 
+  'Computer Hardware Engineering', 'Anatomy', 'Ecology', 'Genetics', 'Neurosciences', 'Communications', 
+  'Animation', 'Journalism', 'Information Technology', 'Aerospace', 'Geography', 'Statistics', 
+  'Environmental Studies', 'Astronomy', 'Public Relations', 'Library Science', 'Anthropology', 'Economics', 
+  'Criminology', 'Archaeology', 'Cartography', 'Political Science', 'Sociology', 'Construction Trades', 
+  'Culinary Arts', 'Creative Writing'
+]
+
+interests.sort.each do |name|
+  Interest.find_or_create_by name: name
+end
+
 ['Unknown', 'Unemployed', 'Quality (Grad School)', 'Quality', 'Part Quality', 'Not Quality', 'Service'].each_with_index do |status, position|
   EmploymentStatus.find_or_create_by! name: status, position: position
 end

--- a/db/migrate/20180710221727_devise_create_users.rb
+++ b/db/migrate/20180710221727_devise_create_users.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      t.string :email
+      t.string :name
+      t.string :first_name
+      t.string :last_name
+      t.boolean :is_administrator
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_09_220458) do
+ActiveRecord::Schema.define(version: 2018_07_10_221727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -303,6 +303,32 @@ ActiveRecord::Schema.define(version: 2018_07_09_220458) do
     t.index ["completed"], name: "index_tasks_on_completed"
     t.index ["due_at"], name: "index_tasks_on_due_at"
     t.index ["taskable_id", "taskable_type"], name: "index_tasks_on_taskable_id_and_taskable_type"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "first_name"
+    t.string "last_name"
+    t.boolean "is_administrator"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,43 +7,10 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 # remove all existing objects to start fresh!
-[Industry, Interest, Employer, Opportunity, OpportunityStage, Fellow].each(&:destroy_all)
-
-industries = [
-  'Accounting', 'Advertising', 'Aerospace', 'Banking', 'Beauty / Cosmetics', 'Biotechnology', 'Business', 
-  'Chemical', 'Communications', 'Computer Engineering', 'Computer Hardware', 'Education', 'Electronics', 
-  'Employment / Human Resources', 'Energy', 'Fashion', 'Film', 'Financial Services', 'Fine Arts', 
-  'Food & Beverage', 'Health', 'Information Technology', 'Insurance', 'Journalism / News / Media', 'Law', 
-  'Management / Strategic Consulting', 'Manufacturing', 'Medical Devices & Supplies', 'Performing Arts', 
-  'Pharmaceutical', 'Public Administration', 'Public Relations', 'Publishing', 'Marketing', 'Real Estate', 
-  'Sports', 'Technology', 'Telecommunications', 'Tourism', 'Transportation / Travel', 'Writing'
-]
-    
-industries.sort.each do |name|
-  Industry.create!(name: name)
-end
+[Employer, Opportunity, OpportunityStage, Fellow].each(&:destroy_all)
 
 industry_accounting = Industry.find_by name: 'Accounting'
-
-interests = [
-  'Accounting', 'African American Studies', 'African Studies', 'Agriculture', 'American Indian Studies', 
-  'American Studies', 'Architecture', 'Asian American Studies', 'Asian Studies', 'Dance', 'Visual Arts', 
-  'Theater', 'Music', 'English / Literature', 'Film', 'Foreign Language', 'Graphic Design', 'Philosophy', 
-  'Religion', 'Business', 'Marketing', 'Actuarial Science', 'Hospitality', 'Human Resources', 'Real Estate', 
-  'Health', 'Public Health', 'Medicine', 'Nursing', 'Gender Studies', 'Urban Studies', 'Latin American Studies', 
-  'European Studies', 'Gay and Lesbian Studies', 'Latinx Studies', 'Women’s Studies', 'Education', 'Psychology', 
-  'Child Development', 'Computer Science', 'History', 'Biology', 'Cognitive Science', 'Human Biology', 
-  'Diversity Studies', 'Marine Sciences', 'Maritime Studies', 'Math', 'Nutrition', 'Sports and Fitness', 
-  'Law / Legal Studies', 'Military', 'Public Administration', 'Social Work', 'Criminal Justice', 'Theology', 
-  'Equestrian Studies', 'Food Science', 'Urban Planning', 'Art History', 'Interior Design', 'Landscape Architecture', 
-  'Chemistry', 'Physics', 'Chemical Engineering', 'Software Engineering', 'Industrial Engineering', 
-  'Civil Engineering', 'Electrical Engineering', 'Mechanical Engineering', 'Biomedical Engineering', 
-  'Computer Hardware Engineering', 'Anatomy', 'Ecology', 'Genetics', 'Neurosciences', 'Communications', 
-  'Animation', 'Journalism', 'Information Technology', 'Aerospace', 'Geography', 'Statistics', 
-  'Environmental Studies', 'Astronomy', 'Public Relations', 'Library Science', 'Anthropology', 'Economics', 
-  'Criminology', 'Archaeology', 'Cartography', 'Political Science', 'Sociology', 'Construction Trades', 
-  'Culinary Arts', 'Creative Writing'
-]
+interest_accounting = Interest.find_by name: 'Accounting'
 
 if Metro.count == 0
   metros = Metro.create([
@@ -54,13 +21,6 @@ if Metro.count == 0
 end
 
 lincoln_ne = Metro.find_by name: 'Lincoln, NE'
-    
-interests.sort.each do |name|
-  Interest.create!(name: name)
-end
-
-interest_accounting = Interest.find_by name: 'Accounting'
-
 
 fruits = ['Apples', 'Bananas', 'Carrots', 'Figs', 'Oranges', 'Raspberries', 'Strawberries']
 

--- a/spec/controllers/fellows_controller_spec.rb
+++ b/spec/controllers/fellows_controller_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe FellowsController, type: :controller do
       
       get :upload, params: {csv: csv}, session: valid_session
       expect(response).to redirect_to(fellows_path)
-      expect(flash[:notice]).to eq('Your file has been uploaded, thanks!')
+      expect(flash[:notice]).to include('Your file is being uploaded, thanks!')
     end
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email){|i| "user#{i}@example.com"}
+    password 'password'
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  let(:user) { create :user }
+  
+  #############
+  # Validations
+  #############
+
+  it { should validate_presence_of :email }
+  
+  describe 'validating uniqueness' do
+    before { user }
+    it { should validate_uniqueness_of(:email).case_insensitive }
+  end
+end


### PR DESCRIPTION
Once we loaded our imperfect real-world fellows into the application, we started having errors when searching for candidates for an opportunity. Why? Because we calculate the distance between candidates and opportunities, and we don't get location information from the PAF Master Roster.

I'm working to see if we can pull this info from Salesforce, but in the mean time this fix does a couple things:

* Use the fellow's cohort site (SJSU, for instance) as their default location
* Add the site's metro area to the fellow's (previously empty) list of metro areas.

Here's a screencap where I do the upload, and verify that new fellows have a default zip code and metro area:

https://drive.google.com/open?id=1LVkHJKFsLdBu3hSMEjeDVTaQMh956Qdx

**Happy Friday the 13th!**

![happy-friday](https://user-images.githubusercontent.com/12893/42698733-6507a0ee-8684-11e8-80fd-8e69d499ecfd.gif)
