### PR TITLE
Fellow Profile Updates

### DIFF
--- a/app/assets/javascripts/employers.coffee
+++ b/app/assets/javascripts/employers.coffee
@@ -43,4 +43,4 @@ $(document).on "turbolinks:load",  ->
           $("##{element}-tags").show()
 
         
-  enableEmployerTagChecklistToggle("industry", '/admin/industries.json', 'Add an Industry')
+  enableEmployerTagChecklistToggle("industry", '/admin/industries/list.json', 'Add an Industry')

--- a/app/assets/javascripts/fellow/profile.coffee
+++ b/app/assets/javascripts/fellow/profile.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/fellows.coffee
+++ b/app/assets/javascripts/fellows.coffee
@@ -42,6 +42,6 @@ $(document).on "turbolinks:load",  ->
           $("##{element}-checklist").hide()
           $("##{element}-tags").show()
         
-  enableFellowTagChecklistToggle("interest", '/admin/interests.json', 'Add an Interest')
-  enableFellowTagChecklistToggle("industry", '/admin/industries.json', 'Add an Industry')
-  enableFellowTagChecklistToggle("metro",    '/admin/metros.json', 'Add a Metro')
+  enableFellowTagChecklistToggle("interest", '/admin/interests/list.json', 'Add an Interest')
+  enableFellowTagChecklistToggle("industry", '/admin/industries/list.json', 'Add an Industry')
+  enableFellowTagChecklistToggle("metro",    '/admin/metros/list.json', 'Add a Metro')

--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -56,8 +56,8 @@ $(document).on "turbolinks:load",  ->
     element = $('#industry-interest-tags textarea') 
     
     if element.length
-      $.get '/admin/industries.json', (industries) ->
-        $.get '/admin/interests.json', (interests) ->
+      $.get '/admin/industries/list.json', (industries) ->
+        $.get '/admin/interests/list.json', (interests) ->
           data = $.unique(industries.concat(interests))
           
           element.show()
@@ -75,9 +75,9 @@ $(document).on "turbolinks:load",  ->
                 $(tag).form().submit()
             
         
-  enableTagChecklistToggle("interest", '/admin/interests.json', 'Add an Interest')
-  enableTagChecklistToggle("industry", '/admin/industries.json', 'Add an Industry')
-  enableTagChecklistToggle("metro",    '/admin/metros.json', 'Add a Metro')
+  enableTagChecklistToggle("interest", '/admin/interests/list.json', 'Add an Interest')
+  enableTagChecklistToggle("industry", '/admin/industries/list.json', 'Add an Industry')
+  enableTagChecklistToggle("metro",    '/admin/metros/list.json', 'Add a Metro')
   
   enableIndustryInterestTags()
   

--- a/app/assets/stylesheets/fellow/profile.scss
+++ b/app/assets/stylesheets/fellow/profile.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the fellow/profile controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/industries_controller.rb
+++ b/app/controllers/admin/industries_controller.rb
@@ -1,5 +1,5 @@
 class Admin::IndustriesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:list, :combined]
   before_action :ensure_admin!, except: [:list, :combined]
   before_action :set_industry, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/admin/interests_controller.rb
+++ b/app/controllers/admin/interests_controller.rb
@@ -1,5 +1,5 @@
 class Admin::InterestsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:list]
   before_action :ensure_admin!, except: [:list]
   before_action :set_interest, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/admin/metros_controller.rb
+++ b/app/controllers/admin/metros_controller.rb
@@ -1,5 +1,5 @@
 class Admin::MetrosController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:list]
   before_action :ensure_admin!, except: [:list]
 
   # GET /metros.json

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,10 +21,25 @@ class ApplicationController < ActionController::Base
   end
   
   def ensure_admin!
+    return if authorized_by_token?
     redirect_to(root_path) unless current_user.is_admin?
   end
   
   def ensure_fellow!
+    return if authorized_by_token?
     redirect_to(root_path) unless current_user.is_fellow?
+  end
+  
+  def authenticate_user!
+    super unless authorized_by_token?
+  end
+  
+  def authorized_by_token?
+    return false unless params[:token]
+    
+    access_token = AccessToken.find_by code: params[:token]
+    return false if access_token.nil?
+
+    access_token.match?(request)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,15 @@ class ApplicationController < ActionController::Base
     
     access_token = AccessToken.find_by code: params[:token]
     return false if access_token.nil?
-
     access_token.match?(request)
+  end
+  
+  def authorize_by_token!
+    fail_token_authorize! unless authorized_by_token?
+  end
+  
+  def fail_token_authorize!
+    flash[:notice] = 'The link you requested is unavailable.'
+    redirect_to root_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,6 +39,7 @@ class ApplicationController < ActionController::Base
     
     access_token = AccessToken.find_by code: params[:token]
     return false if access_token.nil?
+
     access_token.match?(request)
   end
   

--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -2,8 +2,8 @@ class CandidatesController < ApplicationController
   before_action :authorize_by_token!
   
   def status
-    if fellow_opportunity = FellowOpportunity.find_by(id: params[:fellow_opportunity_id])
-      fellow_opportunity.stage = params[:update]
+    if @fellow_opportunity = FellowOpportunity.find_by(id: params[:fellow_opportunity_id])
+      @fellow_opportunity.stage = params[:update].downcase
     else
       fail_token_authorize!
     end

--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -1,0 +1,11 @@
+class CandidatesController < ApplicationController
+  before_action :authorize_by_token!
+  
+  def status
+    if fellow_opportunity = FellowOpportunity.find_by(id: params[:fellow_opportunity_id])
+      fellow_opportunity.stage = params[:update]
+    else
+      fail_token_authorize!
+    end
+  end
+end

--- a/app/controllers/fellow/profiles_controller.rb
+++ b/app/controllers/fellow/profiles_controller.rb
@@ -1,0 +1,35 @@
+class Fellow::ProfilesController < ApplicationController
+  before_action :authenticate_user!, except: [:list, :combined]
+  before_action :ensure_fellow!
+  before_action :set_fellow
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @fellow.update(fellow_params)
+      redirect_to fellow_profile_path, notice: 'Your profile was successfully updated.'
+    else
+      render :edit
+    end
+  end
+  
+  private
+  
+  def set_fellow
+    @fellow = current_user.fellow
+  end
+  
+  def fellow_params
+    params.require(:fellow).permit(
+      :key, :first_name, :last_name, :graduation_year, :graduation_semester,
+      :major, :affiliations, :linkedin_url,
+      :employment_status_id, :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
+      industry_ids: [], interest_ids: [], metro_ids: [],
+      contact_attributes: [:id, :address_1, :address_2, :city, :state, :postal_code, :phone, :email, :url]
+    )
+  end
+end

--- a/app/controllers/fellow/profiles_controller.rb
+++ b/app/controllers/fellow/profiles_controller.rb
@@ -20,6 +20,14 @@ class Fellow::ProfilesController < ApplicationController
   private
   
   def set_fellow
+    unless current_user.fellow
+      current_user.create_fellow(
+        first_name: 'unknown',
+        last_name: 'unknown',
+        employment_status: EmploymentStatus.find_by(position: 0)
+      )
+    end
+    
     @fellow = current_user.fellow
   end
   

--- a/app/controllers/fellows_controller.rb
+++ b/app/controllers/fellows_controller.rb
@@ -1,0 +1,32 @@
+class FellowsController < ApplicationController
+  before_action :authorize_by_token!
+  before_action :set_fellow
+
+  def edit
+    @fellow.build_contact if @fellow.contact.nil?
+  end
+
+  def update
+    unless @fellow.update(fellow_params)
+      render :edit
+    end
+  end
+
+  private
+  
+  def set_fellow
+    @fellow = Fellow.find(params[:id])
+  end
+
+  def fellow_params
+    params.require(:fellow).permit(
+      :key, :first_name, :last_name, :graduation_year, :graduation_semester, :graduation_fiscal_year, 
+      :interests_description, :major, :affiliations, :gpa, :linkedin_url, :staff_notes, :efficacy_score, 
+      :employment_status_id, :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
+      industry_ids: [], 
+      interest_ids: [],
+      metro_ids: [],
+      contact_attributes: [:id, :address_1, :address_2, :city, :state, :postal_code, :phone, :email, :url]
+    )
+  end
+end

--- a/app/controllers/token_controller.rb
+++ b/app/controllers/token_controller.rb
@@ -1,0 +1,10 @@
+class TokenController < ApplicationController
+  def show
+    if access_token = AccessToken.find_by(code: params[:id])
+      redirect_to access_token.path_with_token
+    else
+      flash[:notice] = "The link you requested has expired."
+      redirect_to root_path
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,13 @@
+require 'uri'
+
 module ApplicationHelper
+  def link_to_access_token access_token, label
+    route = access_token.route_for(label)
+    
+    uri = URI.parse(route['path'])
+    new_query = URI.decode_www_form(uri.query || '') << ['token', access_token.code]
+    uri.query = URI.encode_www_form(new_query)
+    
+    link_to route['label'], uri.to_s, method: route['method']
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,8 @@ require 'uri'
 module ApplicationHelper
   def link_to_access_token access_token, label
     route = access_token.route_for(label)
-    token_url = access_token.path_with_token(label)
+    token_url = access_token.path_with_token(label).html_safe
     
-    link_to route['label'], token_url, method: route['method']
+    link_to(route['label'], token_url, method: route['method']).html_safe
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,11 +3,8 @@ require 'uri'
 module ApplicationHelper
   def link_to_access_token access_token, label
     route = access_token.route_for(label)
+    token_url = access_token.path_with_token(label)
     
-    uri = URI.parse(route['path'])
-    new_query = URI.decode_www_form(uri.query || '') << ['token', access_token.code]
-    uri.query = URI.encode_www_form(new_query)
-    
-    link_to route['label'], uri.to_s, method: route['method']
+    link_to route['label'], token_url, method: route['method']
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,10 @@
 require 'uri'
 
 module ApplicationHelper
-  def link_to_access_token access_token, label
+  def link_to_access_token access_token, label, options={}
     route = access_token.route_for(label)
     token_url = access_token.path_with_token(label).html_safe
     
-    link_to(route['label'], token_url, method: route['method']).html_safe
+    link_to(route['label'], token_url, options.merge(method: route['method'])).html_safe
   end
 end

--- a/app/helpers/fellow/profile_helper.rb
+++ b/app/helpers/fellow/profile_helper.rb
@@ -1,0 +1,2 @@
+module Fellow::ProfileHelper
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: Rails.application.secrets.mailer_from_email
   layout 'mailer'
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,0 +1,12 @@
+class CandidateMailer < ApplicationMailer
+  add_template_helper(ApplicationHelper)
+
+  def invitation
+    @token = params[:access_token]
+    @fellow_opp = params[:fellow_opportunity]
+    @fellow = @fellow_opp.fellow
+    @opp = @fellow_opp.opportunity
+    
+    mail(to: @fellow.contact.email, subject: "You've been invited to apply for #{@opp.name}")
+  end
+end

--- a/app/mailers/fellow_mailer.rb
+++ b/app/mailers/fellow_mailer.rb
@@ -1,0 +1,10 @@
+class FellowMailer < ApplicationMailer
+  add_template_helper(ApplicationHelper)
+
+  def profile
+    @token = params[:access_token]
+    @fellow = params[:fellow]
+    
+    mail(to: @fellow.contact.email, subject: "Please Update Your Profile")
+  end
+end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -22,7 +22,8 @@ class AccessToken < ApplicationRecord
     end
   end
   
-  def route_for label
+  def route_for label=nil
+    return routes.first if label.nil?
     routes.detect{|route| route['label'] == label}
   end
   

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -24,6 +24,13 @@ class AccessToken < ApplicationRecord
       ]
     end
     
+    def update_profile fellow
+      create routes: [
+        {label: 'Edit Your Profile', method: 'GET', path: routes.edit_fellow_url(fellow)},
+        {label: 'Update Your Profile', method: 'PATCH', path: routes.fellow_url(fellow)}
+      ]
+    end
+    
     def routes
       Rails.application.routes.url_helpers
     end
@@ -38,7 +45,7 @@ class AccessToken < ApplicationRecord
     routes.any? do |route|
       route['method'].to_s.downcase == request.request_method.downcase &&
       route['path'] == url_without_token(request.original_url) &&
-      code == token_for(request.original_url)
+      code == token_for(request)
     end
   end
   
@@ -88,7 +95,7 @@ class AccessToken < ApplicationRecord
   def url_without_token url
     uri = URI.parse(url)
     
-    new_query = URI.decode_www_form(uri.query)
+    new_query = URI.decode_www_form(uri.query || '')
     new_query.reject!{|key, val| key == 'token'}
     
     uri.query = URI.encode_www_form(new_query)
@@ -99,11 +106,7 @@ class AccessToken < ApplicationRecord
     new_url
   end
   
-  def token_for url
-    uri = URI.parse(url)
-    token_param = CGI.parse(uri.query)['token']
-    
-    return nil if token_param.nil?
-    token_param.first
+  def token_for request
+    request.params[:token]
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -35,6 +35,17 @@ class AccessToken < ApplicationRecord
     end
   end
   
+  def path_with_token label=nil
+    route = route_for(label)
+    
+    uri = URI.parse(route['path'])
+    
+    new_query = URI.decode_www_form(uri.query || '') << ['token', code]
+    uri.query = URI.encode_www_form(new_query)
+    
+    uri.to_s
+  end
+
   private
 
   def generate_token

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -17,6 +17,13 @@ class AccessToken < ApplicationRecord
       ]
     end
     
+    def opportunity_invitation fellow_opportunity
+      create routes: [
+        {label: 'Interested', method: 'GET', path: routes.candidate_status_url(fellow_opportunity.id, update: 'Interested')},
+        {label: 'Not Interested', method: 'GET', path: routes.candidate_status_url(fellow_opportunity.id, update: 'Not Interested')}
+      ]
+    end
+    
     def routes
       Rails.application.routes.url_helpers
     end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -11,7 +11,7 @@ class AccessToken < ApplicationRecord
   class << self
     def fellow_dashboard_view fellow
       create routes: [
-        {label: 'view', method: 'GET', path: routes.admin_fellow_path(fellow)}
+        {label: 'view', method: 'GET', path: routes.admin_fellow_url(fellow)}
       ]
     end
     

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,58 @@
+require 'digest/md5'
+
+class AccessToken < ApplicationRecord
+  serialize :routes, JSON
+  
+  before_validation :generate_token
+
+  validates :code, presence: true, uniqueness: true
+  validate :valid_routes_structure
+  
+  class << self
+    def fellow_dashboard_view fellow
+      create routes: [
+        {label: 'view', method: 'GET', path: routes.admin_fellow_path(fellow)}
+      ]
+    end
+    
+    def routes
+      Rails.application.routes.url_helpers
+    end
+  end
+  
+  def route_for label
+    routes.detect{|route| route['label'] == label}
+  end
+  
+  private
+
+  def generate_token
+    until self.code.to_s =~ /^[0-9a-f]{16}$/ do
+      temp_token = random_token
+      self.code = temp_token unless self.class.where(code: temp_token).count > 0
+    end
+  end
+  
+  def random_token
+    Digest::MD5.hexdigest("#{Time.now}:#{rand}")[0,16]
+  end
+  
+  def valid_routes_structure
+    return set_invalid_routes_message unless routes.is_a?(Array)
+    return errors.add(:routes, "requires at least one route") if routes.empty?
+    
+    routes.each do |route|
+      return set_invalid_routes_message unless route.is_a?(Hash)
+      return set_invalid_routes_message unless route.has_key?('method')
+      return set_invalid_routes_message unless route.has_key?('path')
+    end
+  end
+  
+  def set_invalid_routes_message
+    errors.add(:routes, invalid_routes_message) unless errors[:routes].include?(invalid_routes_message)
+  end
+  
+  def invalid_routes_message
+    "should be an array of hashes with keys 'method' and 'path'"
+  end
+end

--- a/app/models/fellow_opportunity.rb
+++ b/app/models/fellow_opportunity.rb
@@ -10,4 +10,12 @@ class FellowOpportunity < ApplicationRecord
   validates :fellow_id, presence: true, uniqueness: {scope: :opportunity_id}
   validates :opportunity_id, presence: true
   validates :opportunity_stage_id, presence: true
+  
+  def stage
+    opportunity_stage.name
+  end
+  
+  def stage= stage_name
+    self.update opportunity_stage: OpportunityStage.find_by(name: stage_name)
+  end
 end

--- a/app/views/admin/industries/list.json.jbuilder
+++ b/app/views/admin/industries/list.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @industries.pluck(:name)

--- a/app/views/admin/interests/list.json.jbuilder
+++ b/app/views/admin/interests/list.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @interests.pluck(:name)

--- a/app/views/admin/metros/list.json.jbuilder
+++ b/app/views/admin/metros/list.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @metros.pluck(:name)

--- a/app/views/candidate_mailer/invitation.html.erb
+++ b/app/views/candidate_mailer/invitation.html.erb
@@ -9,9 +9,5 @@
 
 <p>Please let us know if you're interested in this opportunity:</p>
 
-<table style="width: 100%">
-  <tr>
-    <td style="width: 50%"><%= link_to_access_token(@token, 'Interested') %></td>
-    <td style="width: 50%"><%= link_to_access_token(@token, 'Not Interested') %></td>
-  </tr>
-</table>
+<%= link_to_access_token(@token, 'Interested', class: 'button') %>
+<%= link_to_access_token(@token, 'Not Interested', class: 'button') %>

--- a/app/views/candidate_mailer/invitation.html.erb
+++ b/app/views/candidate_mailer/invitation.html.erb
@@ -1,0 +1,17 @@
+<h1>Congratulations!</h1>
+
+<p>You have been selected to apply for the following opportunity:</p>
+
+<p>
+  <strong><%= @opp.name %></strong><br>
+  other details here.
+</p>
+
+<p>Please let us know if you're interested in this opportunity:</p>
+
+<table style="width: 100%">
+  <tr>
+    <td style="width: 50%"><%= link_to_access_token(@token, 'Interested') %></td>
+    <td style="width: 50%"><%= link_to_access_token(@token, 'Not Interested') %></td>
+  </tr>
+</table>

--- a/app/views/candidate_mailer/invitation.text.erb
+++ b/app/views/candidate_mailer/invitation.text.erb
@@ -1,0 +1,12 @@
+Congratulations!
+
+You have been selected to apply for the following opportunity:
+
+<%= @opp.name %>
+other details here.
+
+Please let us know if you're interested in this opportunity:
+
+<%= link_to_access_token(@token, 'Interested') %>
+
+<%= link_to_access_token(@token, 'Not Interested') %>

--- a/app/views/candidate_mailer/invitation.text.erb
+++ b/app/views/candidate_mailer/invitation.text.erb
@@ -7,6 +7,6 @@ other details here.
 
 Please let us know if you're interested in this opportunity:
 
-@token.path_with_token('Interested')
+<%= @token.path_with_token('Interested') %>
 
-@token.path_with_token('Not Interested')
+<%= @token.path_with_token('Not Interested') %>

--- a/app/views/candidate_mailer/invitation.text.erb
+++ b/app/views/candidate_mailer/invitation.text.erb
@@ -7,6 +7,6 @@ other details here.
 
 Please let us know if you're interested in this opportunity:
 
-<%= link_to_access_token(@token, 'Interested') %>
+@token.path_with_token('Interested')
 
-<%= link_to_access_token(@token, 'Not Interested') %>
+@token.path_with_token('Not Interested')

--- a/app/views/candidates/status.html.erb
+++ b/app/views/candidates/status.html.erb
@@ -1,0 +1,3 @@
+<h1>Thank you!</h1>
+
+<p>Your status for this opportunity is now "<%= @fellow_opportunity.stage %>".</p>

--- a/app/views/fellow/home/welcome.html.erb
+++ b/app/views/fellow/home/welcome.html.erb
@@ -1,1 +1,3 @@
 <h1>Fellow Dashboard</h1>
+
+<%= link_to 'Your Profile', fellow_profile_path %>

--- a/app/views/fellow/profiles/_form.html.erb
+++ b/app/views/fellow/profiles/_form.html.erb
@@ -1,0 +1,79 @@
+<%= form_with(model: [:fellow, fellow], local: true, url: fellow_profile_path, html: {method: 'patch'}) do |form| %>
+  <%= hidden_field_tag :token, params[:token] %>
+  
+  <% if fellow.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(fellow.errors.count, "error") %> prohibited this profile from being saved:</h2>
+
+      <ul>
+      <% fellow.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :first_name %>
+    <%= form.text_field :first_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :last_name %>
+    <%= form.text_field :last_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :graduation_year %>
+    <%= form.number_field :graduation_year %>
+  </div>
+
+  <div class="field">
+    <%= form.label :graduation_semester %>
+    <%= form.select :graduation_semester, options_for_select(Course::VALID_SEMESTERS) %>
+  </div>
+
+  <div class="field">
+    <%= form.label :major %>
+    <%= form.text_field :major %>
+  </div>
+
+  <div class="field">
+    <%= form.label :affiliations %>
+    <%= form.text_area :affiliations %>
+  </div>
+
+  <div class="field">
+    <%= form.label :linkedin_url %>
+    <%= form.text_field :linkedin_url %>
+  </div>
+
+  <div class="field">
+    <%= form.label :employment_status_id %>
+    <%= form.collection_select(:employment_status_id, EmploymentStatus.all, :id, :name) %>
+  </div>
+  
+  <hr>
+
+  <%= render 'admin/contacts/nested_form', form: form %>
+  
+  <h3>Industries/Interests</h3>
+
+  <%= link_to 'full industries/interests list', combined_admin_industries_path, target: '_blank' %>
+
+  <div id="industry-interest-tags" class="jquery-tags">
+    <%= form.text_area :industry_interest_tags %>
+  </div>
+  
+  <h3>Metro Areas</h3>
+  
+  <%= link_to 'full metro areas list', list_admin_metros_path, target: '_blank' %>
+
+  <div id="metro-tags" class="jquery-tags">
+    <%= form.text_area :metro_tags %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit 'Update Profile' %>
+  </div>
+<% end %>

--- a/app/views/fellow/profiles/edit.html.erb
+++ b/app/views/fellow/profiles/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Update Your Profile</h1>
+
+<%= render 'form', fellow: @fellow %>
+
+<%= link_to 'Back', fellow_profile_path(@fellow) %>
+

--- a/app/views/fellow/profiles/show.html.erb
+++ b/app/views/fellow/profiles/show.html.erb
@@ -1,0 +1,49 @@
+<h1>Your Profile</h1>
+
+<table>
+  <tbody>
+    <tr class="name">
+      <th>Name:</th>
+      <td><%= @fellow.full_name %></td>
+    </tr>
+    <tr class="key">
+      <th>Key:</th>
+      <td><%= @fellow.key %></td>
+    </tr>
+    <tr class="new-section">
+      <th>Graduation:</th>
+      <td><%= @fellow.graduation_semester %> <%= @fellow.graduation_year %></td>
+    </tr>
+    <tr class="new-section">
+      <th>Industries/Interests:</th>
+      <td><%= @fellow.industry_interest_tags.gsub(';', ', ') %></td>
+    </tr>
+    <tr class="new-section">
+      <th>Available In:</th>
+      <td><%= @fellow.metro_tags.gsub(';', ', ') %></td>
+    </tr>
+    <tr>
+      <th>Major:</th>
+      <td><%= @fellow.major %></td>
+    </tr>
+    <tr>
+      <th>Affiliations:</th>
+      <td><%= @fellow.affiliations %></td>
+    </tr>
+    <tr>
+      <th>GPA:</th>
+      <td><%= @fellow.gpa %></td>
+    </tr>
+    <tr>
+      <th>Linkedin url:</th>
+      <td><%= @fellow.linkedin_url %></td>
+    </tr>
+    <tr>
+      <th>Employment status:</th>
+      <td><%= @fellow.employment_status.name %></td>
+    </tr>
+  </tbody>
+</table>
+
+<%= link_to 'Edit', edit_fellow_profile_path %> |
+<%= link_to 'Back', root_path %>

--- a/app/views/fellow_mailer/invitation.html.erb
+++ b/app/views/fellow_mailer/invitation.html.erb
@@ -1,0 +1,13 @@
+<h1>Congratulations!</h1>
+
+<p>You have been selected to apply for the following opportunity:</p>
+
+<p>
+  <strong><%= @opp.name %></strong><br>
+  other details here.
+</p>
+
+<p>Please let us know if you're interested in this opportunity:</p>
+
+<%= link_to_access_token(@token, 'Interested', class: 'button') %>
+<%= link_to_access_token(@token, 'Not Interested', class: 'button') %>

--- a/app/views/fellow_mailer/invitation.text.erb
+++ b/app/views/fellow_mailer/invitation.text.erb
@@ -1,0 +1,12 @@
+Congratulations!
+
+You have been selected to apply for the following opportunity:
+
+<%= @opp.name %>
+other details here.
+
+Please let us know if you're interested in this opportunity:
+
+<%= @token.path_with_token('Interested') %>
+
+<%= @token.path_with_token('Not Interested') %>

--- a/app/views/fellow_mailer/profile.html.erb
+++ b/app/views/fellow_mailer/profile.html.erb
@@ -1,0 +1,3 @@
+<p>To help us find better opportunity matches for you, please take a few minutes to update your profile:</p>
+
+<p><%= link_to_access_token(@token, 'Edit Your Profile', class: 'button') %></p>

--- a/app/views/fellow_mailer/profile.text.erb
+++ b/app/views/fellow_mailer/profile.text.erb
@@ -1,0 +1,3 @@
+To help us find better opportunity matches for you, please take a few minutes to update your profile:
+
+<%= @token.path_with_token('Edit Your Profile') %>

--- a/app/views/fellows/_form.html.erb
+++ b/app/views/fellows/_form.html.erb
@@ -34,11 +34,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :graduation_fiscal_year %>
-    <%= form.number_field :graduation_fiscal_year %>
-  </div>
-
-  <div class="field">
     <%= form.label :major %>
     <%= form.text_field :major %>
   </div>

--- a/app/views/fellows/_form.html.erb
+++ b/app/views/fellows/_form.html.erb
@@ -1,0 +1,84 @@
+<%= form_with(model: [fellow], local: true) do |form| %>
+  <%= hidden_field_tag :token, params[:token] %>
+  
+  <% if fellow.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(fellow.errors.count, "error") %> prohibited this profile from being saved:</h2>
+
+      <ul>
+      <% fellow.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :first_name %>
+    <%= form.text_field :first_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :last_name %>
+    <%= form.text_field :last_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :graduation_year %>
+    <%= form.number_field :graduation_year %>
+  </div>
+
+  <div class="field">
+    <%= form.label :graduation_semester %>
+    <%= form.select :graduation_semester, options_for_select(Course::VALID_SEMESTERS) %>
+  </div>
+
+  <div class="field">
+    <%= form.label :graduation_fiscal_year %>
+    <%= form.number_field :graduation_fiscal_year %>
+  </div>
+
+  <div class="field">
+    <%= form.label :major %>
+    <%= form.text_field :major %>
+  </div>
+
+  <div class="field">
+    <%= form.label :affiliations %>
+    <%= form.text_area :affiliations %>
+  </div>
+
+  <div class="field">
+    <%= form.label :linkedin_url %>
+    <%= form.text_field :linkedin_url %>
+  </div>
+
+  <div class="field">
+    <%= form.label :employment_status_id %>
+    <%= form.collection_select(:employment_status_id, EmploymentStatus.all, :id, :name) %>
+  </div>
+  
+  <hr>
+
+  <%= render 'admin/contacts/nested_form', form: form %>
+  
+  <h3>Industries/Interests</h3>
+
+  <%= link_to 'full industries/interests list', combined_admin_industries_path, target: '_blank' %>
+
+  <div id="industry-interest-tags" class="jquery-tags">
+    <%= form.text_area :industry_interest_tags %>
+  </div>
+  
+  <h3>Metro Areas</h3>
+  
+  <%= link_to 'full metro areas list', list_admin_metros_path, target: '_blank' %>
+
+  <div id="metro-tags" class="jquery-tags">
+    <%= form.text_area :metro_tags %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit 'Update Profile' %>
+  </div>
+<% end %>

--- a/app/views/fellows/edit.html.erb
+++ b/app/views/fellows/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Update Your Profile</h1>
+
+<%= render 'form', fellow: @fellow %>

--- a/app/views/fellows/update.html.erb
+++ b/app/views/fellows/update.html.erb
@@ -1,0 +1,3 @@
+<h1>Thanks!</h1>
+
+<p>Your profile has been updated, which will help us match you with high quality opportunities.</p>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -4,6 +4,36 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>
       /* Email styles need to be inline */
+
+      a:link, a:visited {
+        color: #0081bd;
+        text-decoration: none;
+        background: none;
+      }
+
+      a:hover, a:active {
+        text-decoration: underline;
+      }
+
+      a.button {
+        font-size: 0.8em;
+        background: #EB3B46;
+        color: #FFF;
+        border: none;
+        text-transform: uppercase;
+        font-weight: bold;
+        border-radius: 3px;
+        transition: background-color 0.2s ease-in-out;
+        padding: 8px 14px;
+        margin-bottom: 0;
+        margin-right: 20px;
+        line-height: 1;
+      }
+
+      a.button:hover {
+        background: #c8141f;
+        text-decoration: none;
+      }
     </style>
   </head>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
 
   namespace :fellow do
     get 'home/welcome'
+    
+    resource :profile, only: [:show, :edit, :update]
   end
 
   namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  default_url_options Rails.application.config.action_mailer.default_url_options
+
   devise_for :users, controllers: { confirmations: 'confirmations', sessions: 'sessions', passwords: 'passwords' }
 
   get 'home/welcome'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { confirmations: 'confirmations', sessions: 'sessions', passwords: 'passwords' }
 
   get 'home/welcome'
+  get 'token/:id', to: 'token#show', as: 'token'
   
   namespace :fellow do
     get 'home/welcome'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
 
   get 'home/welcome'
   get 'token/:id', to: 'token#show', as: 'token'
+
+  get 'candidates/:fellow_opportunity_id/status', to: 'candidates#status', as: 'candidate_status'
   
   namespace :fellow do
     get 'home/welcome'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
 
   get 'candidates/:fellow_opportunity_id/status', to: 'candidates#status', as: 'candidate_status'
   
+  resources :fellows, only: [:edit, :update]
+
   namespace :fellow do
     get 'home/welcome'
   end

--- a/db/init.rb
+++ b/db/init.rb
@@ -40,6 +40,20 @@ end
   EmploymentStatus.find_or_create_by! name: status, position: position
 end
 
+OpportunityStage.create!([
+  {position: 0, probability: 0.01, name: 'notified'},
+  {position: 1, probability: 0.05, name: 'interested'},
+  {position: 2, probability: 0.0,  name: 'not interested'},
+  {position: 3, probability: 0.1,  name: 'applying'},
+  {position: 4, probability: 0.15, name: 'application submitted'},
+  {position: 5, probability: 0.35, name: 'interview scheduled'},
+  {position: 6, probability: 0.55, name: 'interview completed'},
+  {position: 7, probability: 0.9,  name: 'offered'},
+  {position: 8, probability: 0.95, name: 'accepted'},
+  {position: 9, probability: 1.0,  name: 'committed'},
+  {position: 10, probability: 0.0,  name: 'rejected'}
+])
+
 nlu = Site.find_or_create_by code: 'NLU', name: 'National Louis University'
 nlu.update(
   location_attributes: {

--- a/db/migrate/20180724154954_create_access_tokens.rb
+++ b/db/migrate/20180724154954_create_access_tokens.rb
@@ -1,0 +1,12 @@
+class CreateAccessTokens < ActiveRecord::Migration[5.2]
+  def change
+    create_table :access_tokens do |t|
+      t.string :code
+      t.text :routes
+
+      t.timestamps
+    end
+    
+    add_index :access_tokens, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_20_225032) do
+ActiveRecord::Schema.define(version: 2018_07_24_154954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "access_tokens", force: :cascade do |t|
+    t.string "code"
+    t.text "routes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_access_tokens_on_code", unique: true
+  end
 
   create_table "coaches", force: :cascade do |t|
     t.string "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,11 +52,14 @@ end
 opportunity_stages = OpportunityStage.create!([
   {position: 0, probability: 0.01, name: 'notified'},
   {position: 1, probability: 0.05, name: 'interested'},
-  {position: 2, probability: 0.1,  name: 'applying'},
-  {position: 3, probability: 0.15, name: 'application submitted'},
-  {position: 4, probability: 0.95, name: 'accepted'},
-  {position: 5, probability: 1.0,  name: 'committed'},
-  {position: 6, probability: 0.0,  name: 'rejected'}
+  {position: 2, probability: 0.0,  name: 'not interested'},
+  {position: 3, probability: 0.1,  name: 'applying'},
+  {position: 4, probability: 0.15, name: 'application submitted'},
+  {position: 5, probability: 0.35, name: 'interview scheduled'},
+  {position: 6, probability: 0.55, name: 'interview completed'},
+  {position: 7, probability: 0.95, name: 'accepted'},
+  {position: 8, probability: 1.0,  name: 'committed'},
+  {position: 9, probability: 0.0,  name: 'rejected'}
 ])
 
 employment_status = EmploymentStatus.order('position asc').first

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 # remove all existing objects to start fresh!
-[Employer, Opportunity, OpportunityStage, Fellow].each(&:destroy_all)
+[Employer, Opportunity, Fellow].each(&:destroy_all)
 
 industry_accounting = Industry.find_by name: 'Accounting'
 interest_accounting = Interest.find_by name: 'Accounting'
@@ -48,19 +48,6 @@ fruits = ['Apples', 'Bananas', 'Carrots', 'Figs', 'Oranges', 'Raspberries', 'Str
     opportunity.metros << lincoln_ne
   end
 end
-
-opportunity_stages = OpportunityStage.create!([
-  {position: 0, probability: 0.01, name: 'notified'},
-  {position: 1, probability: 0.05, name: 'interested'},
-  {position: 2, probability: 0.0,  name: 'not interested'},
-  {position: 3, probability: 0.1,  name: 'applying'},
-  {position: 4, probability: 0.15, name: 'application submitted'},
-  {position: 5, probability: 0.35, name: 'interview scheduled'},
-  {position: 6, probability: 0.55, name: 'interview completed'},
-  {position: 7, probability: 0.95, name: 'accepted'},
-  {position: 8, probability: 1.0,  name: 'committed'},
-  {position: 9, probability: 0.0,  name: 'rejected'}
-])
 
 employment_status = EmploymentStatus.order('position asc').first
 

--- a/lib/taggable.rb
+++ b/lib/taggable.rb
@@ -48,7 +48,7 @@ module Taggable
   
   module IndustryInterestMethods
     def industry_interest_tags
-      (industries.pluck(:name) | interests.pluck(:name)).join(';')
+      (industries.pluck(:name) | interests.pluck(:name)).sort.join(';')
     end
   
     def industry_interest_tags= tag_string

--- a/spec/controllers/candidates_controller_spec.rb
+++ b/spec/controllers/candidates_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidatesController, type: :controller do
-  let(:opportunity_stage) { create :opportunity_stage, name: 'Interested' }
+  let(:opportunity_stage) { create :opportunity_stage, name: 'interested' }
   
   let(:access_token) { create :access_token, code: code, routes: route_list }
   let(:code) { 'aaaabbbbccccdddd' }
@@ -48,7 +48,7 @@ RSpec.describe CandidatesController, type: :controller do
     
     it "updates the fellow_opportunity stage" do
       get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'Interested', token: access_token.code}
-      expect(fellow_opportunity.reload.stage).to eq('Interested')
+      expect(fellow_opportunity.reload.stage).to eq('interested')
     end
   end
 end

--- a/spec/controllers/candidates_controller_spec.rb
+++ b/spec/controllers/candidates_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe CandidatesController, type: :controller do
+  let(:opportunity_stage) { create :opportunity_stage, name: 'Interested' }
+  
+  let(:access_token) { create :access_token, code: code, routes: route_list }
+  let(:code) { 'aaaabbbbccccdddd' }
+  let(:route_list) { [route_interested, route_not_interested, route_bad_id] }
+  let(:route_interested) { {'label' => 'Interested', 'method' => 'GET', 'path' => candidate_status_url(fellow_opportunity.id, update: 'Interested')} }
+  let(:route_not_interested) { {'label' => 'Not Interested', 'method' => 'GET', 'path' => candidate_status_url(fellow_opportunity.id, update: 'Not Interested')} }
+  let(:route_bad_id) { {'label' => 'Interested', 'method' => 'GET', 'path' => candidate_status_url(fellow_opportunity.id, update: 'Interested')} }
+  
+  
+  let(:fellow_opportunity) { create :fellow_opportunity, fellow: fellow, opportunity: opportunity }
+  let(:fellow) { create :fellow }
+  let(:opportunity) { create :opportunity }
+  
+  before do
+    opportunity_stage; access_token; fellow_opportunity
+  end
+  
+  describe "GET #status" do
+    it "redirects without token" do
+      get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'Interested'}
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to include('The link you requested is unavailable')
+    end
+    
+    it "redirects with bad token" do
+      get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'Interested', token: 'badtoken'}
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to include('The link you requested is unavailable')
+    end
+    
+    it "redirects with bad fellow_opp id" do
+      get :status, params: {fellow_opportunity_id: '1001', update: 'Interested', token: access_token.code}
+      
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to include('The link you requested is unavailable')
+    end
+    
+    it "returns http success" do
+      get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'Interested', token: access_token.code}
+      expect(response).to be_successful
+    end
+    
+    it "updates the fellow_opportunity stage" do
+      get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'Interested', token: access_token.code}
+      expect(fellow_opportunity.reload.stage).to eq('Interested')
+    end
+  end
+end

--- a/spec/controllers/fellow/profiles_controller_spec.rb
+++ b/spec/controllers/fellow/profiles_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Fellow::ProfilesController, type: :controller do
+  render_views
+  
+  let(:user) { create :fellow_user }
+  let(:fellow) { create :fellow, contact: create(:contact) }
+  
+  before do 
+    user.fellow = fellow
+    sign_in user
+  end
+
+  let(:valid_attributes) { attributes_for :fellow }
+  let(:invalid_attributes) { {name: ''} }
+  let(:valid_session) { {} }
+
+  describe "GET #show" do
+    it "returns a success response" do
+      get :show, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #edit" do
+    it "returns a success response" do
+      get :edit, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "PUT #update" do
+    context "with valid params" do
+      let(:new_last_name) { fellow.last_name + 'x' }
+
+      it "updates the requested industry" do
+        put :update, params: {fellow: {last_name: new_last_name}}, session: valid_session
+        fellow.reload
+        
+        expect(fellow.last_name).to eq(new_last_name)
+      end
+
+      it "redirects to the industries list" do
+        put :update, params: {fellow: {last_name: new_last_name}}, session: valid_session
+        expect(response).to redirect_to(fellow_profile_path)
+      end
+
+      it "creates update notice message" do
+        put :update, params: {fellow: {last_name: new_last_name}}, session: valid_session
+        expect(flash[:notice]).to include('updated')
+      end
+    end
+
+    context "with invalid params" do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        put :update, params: {fellow: {graduation_year: 4000}}, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/controllers/fellows_controller_spec.rb
+++ b/spec/controllers/fellows_controller_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe FellowsController, type: :controller do
+  render_views
+  
+  let(:fellow) { create :fellow, contact: create(:contact, email: email)}
+  let(:email) { 'test@example.com' }
+  
+  let(:access_token) { create :access_token, code: code, routes: route_list }
+  let(:code) { 'aaaabbbbccccdddd' }
+  let(:route_list) { [route_edit, route_update] }
+  let(:route_edit) { {'label' => 'Edit Your Profile', 'method' => 'GET', 'path' => edit_fellow_url(fellow.id)} }
+  let(:route_update) { {'label' => 'Update Your Profile', 'method' => 'PUT', 'path' => fellow_url(fellow.id)} }
+
+  let(:employment_status) { build :employment_status, id: 1001 }
+  let(:industry) { create :industry }
+  let(:interest) { create :interest }
+
+  let(:valid_attributes) { attributes_for :fellow, employment_status_id: employment_status.id }
+  let(:invalid_attributes) { {first_name: ''} }
+
+  let(:valid_session) { {} }
+
+  before do
+    access_token; fellow
+    allow_any_instance_of(Fellow).to receive(:employment_status).and_return(employment_status)
+  end
+  
+  describe "GET #edit" do
+    describe 'without token' do
+      before { get :edit, params: {id: fellow.id} }
+      
+      it "redirects" do
+        expect(response).to redirect_to(root_path)
+      end
+      
+      it "sets flash notice" do
+        expect(flash[:notice]).to include('unavailable')
+      end
+    end
+    
+    it "returns http success" do
+      get :edit, params: {id: fellow.id, token: code}
+      expect(response).to be_successful
+    end
+  end
+
+  describe "PUT #update" do
+    describe 'without token' do
+      before { put :update, params: {id: fellow.id, fellow: {}} }
+      
+      it "redirects" do
+        expect(response).to redirect_to(root_path)
+      end
+      
+      it "sets flash notice" do
+        expect(flash[:notice]).to include('unavailable')
+      end
+    end
+
+    context "with valid params" do
+      let(:new_first_name) { valid_attributes[:first_name] + ' 2' }
+      let(:new_attributes) { {first_name: new_first_name} }
+
+      it "updates the requested fellow" do
+        put :update, params: {id: fellow.to_param, token: code, fellow: new_attributes}, session: valid_session
+        fellow.reload
+      
+        expect(fellow.first_name).to eq(new_first_name)
+      end
+
+      it "redirects to the fellow" do
+        put :update, params: {id: fellow.to_param, token: code, fellow: valid_attributes}, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+
+    it "associates specified industries with the fellow" do
+      put :update, params: {id: fellow.to_param, token: code, fellow: valid_attributes.merge(industry_ids: [industry.id.to_s])}, session: valid_session
+      fellow.reload
+  
+      expect(fellow.industries).to include(industry)
+    end
+
+    it "associates specified interests with the fellow" do
+      put :update, params: {id: fellow.to_param, token: code, fellow: valid_attributes.merge(interest_ids: [interest.id.to_s])}, session: valid_session
+      fellow.reload
+  
+      expect(fellow.interests).to include(interest)
+    end
+
+    context "with invalid params" do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        put :update, params: {id: fellow.to_param, token: code, fellow: invalid_attributes}, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/controllers/token_controller_spec.rb
+++ b/spec/controllers/token_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe TokenController, type: :controller do
+  let(:access_token) { create :access_token, code: code, routes: [route_one, route_two] }
+  let(:code) { 'aaaabbbbccccdddd' }
+  let(:route_one) { {'label' => 'one', 'method' => 'GET', 'path' => '/admin/industries/list'} }
+  let(:route_two) { {'label' => 'two', 'method' => 'GET', 'path' => '/admin/interests/list'} }
+
+  describe "GET #show" do
+    describe 'token path' do
+      it "creates the right path" do
+        expect(token_path('1001')).to eq('/token/1001')
+      end
+    end
+    
+    describe 'when token is valid' do
+      before { get :show, params: {id: access_token.code} }
+      
+      it "redirects to the first route" do
+        expect(response).to redirect_to("/admin/industries/list?token=#{code}")
+      end
+    end
+    
+    describe 'when token is invalid' do
+      before { get :show, params: {id: '1111111111111111'} }
+      
+      it "redirects to root path" do
+        expect(response).to redirect_to(root_path)
+      end
+      
+      it "sets the flash message" do
+        expect(flash[:notice]).to include('expired')
+      end
+    end
+  end
+end

--- a/spec/factories/access_tokens.rb
+++ b/spec/factories/access_tokens.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :access_token do
+    routes [{method: 'GET', path: '/test/this'}]
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe ApplicationHelper, type: :helper do
     subject { link_to_access_token(access_token, label) }
     describe "when there are no other parameters" do
       let(:label) { 'view' }
-      it { should eq(link_to 'view', "/fellow/home/welcome?token=#{code}", method: 'GET') }
+      it { should eq(link_to 'view', "/fellow/home/welcome?token=#{code}".html_safe, method: 'GET') }
     end
     
     describe "when there are other parameters" do
       let(:label) { 'other' }
-      it { should eq(link_to 'other', "/other?test=true&token=#{code}", method: 'POST') }
+      it { should eq(link_to('other', "/other?test=true&token=#{code}".html_safe, method: 'POST')) }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ApplicationHelper. For example:
+#
+# describe ApplicationHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ApplicationHelper, type: :helper do
+  describe 'link_to_access_token(access_token, label)' do
+    let(:code) { 'aaaaaaaaaaaaaaaa' }
+    let(:view_route) { {'label' => 'view', 'method' => 'GET', 'path' => '/fellow/home/welcome'} }
+    let(:other_route) { {'label' => 'other', 'method' => 'POST', 'path' => '/other?test=true'} }
+    let(:access_token) { build :access_token, code: code, routes: [view_route, other_route] }
+    
+    subject { link_to_access_token(access_token, label) }
+    describe "when there are no other parameters" do
+      let(:label) { 'view' }
+      it { should eq(link_to 'view', "/fellow/home/welcome?token=#{code}", method: 'GET') }
+    end
+    
+    describe "when there are other parameters" do
+      let(:label) { 'other' }
+      it { should eq(link_to 'other', "/other?test=true&token=#{code}", method: 'POST') }
+    end
+  end
+end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+require 'nokogiri'
+
+RSpec.describe CandidateMailer, type: :mailer do
+  describe 'invitation' do
+    let(:access_token) { AccessToken.opportunity_invitation(fellow_opportunity) }
+
+    let(:fellow_opportunity) { create :fellow_opportunity, fellow: fellow, opportunity: opportunity }
+    let(:fellow) { create :fellow, contact: create(:contact, email: email) }
+    let(:email) { 'test@example.com' }
+    let(:opportunity) { create :opportunity, name: "New Opportunity" }
+
+    let(:mail) { CandidateMailer.with(access_token: access_token, fellow_opportunity: fellow_opportunity).invitation }
+    
+    it "renders the headers" do
+      expect(mail.subject).to eq("You've been invited to apply for New Opportunity")
+      expect(mail.to).to include(email)
+      expect(mail.from).to include(Rails.application.secrets.mailer_from_email)
+    end
+    
+    it "renders the body with interest links" do
+      body = mail.body.encoded
+      
+      expect(body).to include(opportunity.name)
+      expect(body).to include("http://localhost:3011/candidates/#{fellow_opportunity.id}/status?update=Interested&token=#{access_token.code}")
+      expect(body).to include("http://localhost:3011/candidates/#{fellow_opportunity.id}/status?update=Not+Interested&token=#{access_token.code}")
+    end
+  end
+end

--- a/spec/mailers/fellow_mailer_spec.rb
+++ b/spec/mailers/fellow_mailer_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require 'nokogiri'
+
+RSpec.describe FellowMailer, type: :mailer do
+  describe 'profile' do
+    let(:access_token) { AccessToken.update_profile(fellow) }
+
+    let(:fellow) { create :fellow, contact: create(:contact, email: email) }
+    let(:email) { 'test@example.com' }
+
+    let(:mail) { FellowMailer.with(access_token: access_token, fellow: fellow).profile }
+    
+    it "renders the headers" do
+      expect(mail.subject).to eq("Please Update Your Profile")
+      expect(mail.to).to include(email)
+      expect(mail.from).to include(Rails.application.secrets.mailer_from_email)
+    end
+    
+    it "renders the body with interest links" do
+      body = mail.body.encoded
+      expect(body).to include("http://localhost:3011/fellows/#{fellow.id}/edit?token=#{access_token.code}")
+    end
+  end
+end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/candidate_mailer
+class CandidateMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -1,4 +1,9 @@
 # Preview all emails at http://localhost:3000/rails/mailers/candidate_mailer
 class CandidateMailerPreview < ActionMailer::Preview
+  def invitation
+    fellow_opportunity = FellowOpportunity.last
+    access_token = AccessToken.last
 
+    CandidateMailer.with(access_token: access_token, fellow_opportunity: fellow_opportunity).invitation
+  end
 end

--- a/spec/mailers/previews/fellow_mailer_preview.rb
+++ b/spec/mailers/previews/fellow_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/fellow_mailer
+class FellowMailerPreview < ActionMailer::Preview
+  def profile
+    fellow = Fellow.last
+    access_token = AccessToken.last
+
+    FellowMailer.with(access_token: access_token, fellow: fellow).profile
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -135,4 +135,32 @@ RSpec.describe AccessToken, type: :model do
 
     it { should eq(route) }
   end
+  
+  describe 'match?(request)' do
+    let(:code) { 'aaaabbbbccccdddd' }
+    let(:route_first) { {'label' => 'first', 'method' => 'GET', 'path' => 'http://localhost:3011/first'} }
+    let(:route_second) { {'label' => 'second', 'method' => 'POST', 'path' => 'http://localhost:3011/second'} }
+    
+    subject { build :access_token, code: code, routes: [route_first, route_second] }
+    
+    it "returns true if any route matches method AND path, minus token parameter" do
+      request = double('request', original_url: "http://localhost:3011/second?token=#{code}", request_method: 'POST')
+      expect(subject.match?(request)).to be(true)
+    end
+    
+    it "returns false if the token doesn't match" do
+      request = double('request', original_url: "http://localhost:3011/second?token=#{code}x", request_method: 'POST')
+      expect(subject.match?(request)).to be(false)
+    end
+    
+    it "returns false if request method doesn't match" do
+      request = double('request', original_url: "http://localhost:3011/second?token=#{code}", request_method: 'GET')
+      expect(subject.match?(request)).to be(false)
+    end
+    
+    it "returns false if original url (minus token) doesn't match" do
+      request = double('request', original_url: "http://localhoster:3011/second?token=#{code}", request_method: 'POST')
+      expect(subject.match?(request)).to be(false)
+    end
+  end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -128,12 +128,22 @@ RSpec.describe AccessToken, type: :model do
   ##################
 
   describe 'route_for(label)' do
-    let(:route) { {'label' => 'tester', 'method' => 'GET', 'path' => '/test/this'} }
-    let(:access_token) { AccessToken.create routes: [route] }
+    let(:route_one) { {'label' => 'one', 'method' => 'GET', 'path' => '/test/one'} }
+    let(:route_two) { {'label' => 'two', 'method' => 'POST', 'path' => '/test/two'} }
     
-    subject { access_token.route_for('tester') }
+    let(:access_token) { AccessToken.create routes: [route_one, route_two] }
+    
+    it "provides the requested route by label" do
+      expect(access_token.route_for('two')).to eq(route_two)
+    end
+    
+    it "provides first route by default" do
+      expect(access_token.route_for()).to eq(route_one)
+    end
 
-    it { should eq(route) }
+    it "provides first route when nil is specified" do
+      expect(access_token.route_for(nil)).to eq(route_one)
+    end
   end
   
   describe 'match?(request)' do

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe AccessToken, type: :model do
+  #############
+  # Validations
+  #############
+  
+  # validating the code attribute requires disabling :generate_token, which always results in a valid code.
+
+  describe 'validating presence' do
+    before { allow_any_instance_of(AccessToken).to receive(:generate_token).and_return(nil) }
+    it { should validate_presence_of :code }
+  end
+  
+  describe 'validating uniqueness' do
+    before do
+      allow_any_instance_of(AccessToken).to receive(:generate_token).and_return(nil)
+      create :access_token, code: '11112222aaaabbbb'
+    end
+    
+    it { should validate_uniqueness_of :code }
+  end
+  
+  describe 'validating routes' do
+    let(:access_token) { build :access_token, routes: routes }
+    let(:error_message) { access_token.send(:invalid_routes_message) }
+    
+    before { access_token.valid? }
+    
+    subject { access_token.errors[:routes] }
+    
+    describe "when an array of hashes, with keys 'method' and 'path'" do
+      let(:routes) { [{'method' => 'GET', 'path' => '/this/path'}] }
+      it { should be_empty }
+    end
+    
+    describe 'when not an array' do
+      let(:routes) { {test: 'this'} }
+      it { should include(error_message) }
+    end
+    
+    describe 'when array is empty' do
+      let(:routes) { [] }
+      it { should include("requires at least one route") }
+    end
+    
+    describe 'when not an array of hashes' do
+      let(:routes) { ['test', 'this'] }
+      it { should include(error_message) }
+    end
+    
+    describe 'when not all hashes have method key' do
+      let(:routes) { [{'method' => 'GET', 'path' => '/test/this'}, {'path' => '/get/another'}] }
+      it { should include(error_message) }
+    end
+    
+    describe 'when not all hashes have path key' do
+      let(:routes) { [{'method' => 'GET', 'path' => '/test/this'}, {'method' => 'POST'}] }
+      it { should include(error_message) }
+    end
+  end
+
+  ###########
+  # Callbacks
+  ###########
+
+  describe 'generating code' do
+    let(:access_token) { build :access_token}
+    
+    it "generates code upon create" do
+      access_token.save
+      expect(access_token.code).to match(/^[0-9a-f]{16}$/)
+    end
+    
+    it "generates new code when old code is invalid" do
+      access_token.code = '123'
+      access_token.save
+      
+      expect(access_token.reload.code).to match(/^[0-9a-f]{16}$/)
+    end
+    
+    describe 'when generated code is already taken' do
+      let(:first_code) { '0000000000000000' }
+      let(:second_code) { '1111111111111111' }
+      
+      before do
+        create :access_token, code: first_code
+        allow(access_token).to receive(:random_token).and_return(first_code, second_code)
+      end
+      
+      it "tries new codes until it finds something unique" do
+        access_token.save
+        expect(access_token.code).to eq(second_code)
+      end
+    end
+  end
+  
+  ###############
+  # Serialization
+  ###############
+
+  describe 'routes' do
+    it "is stored as JSON" do
+      access_token = AccessToken.create routes: [{method: 'GET', path: '/test/this'}]
+      access_token.reload
+      
+      expect(access_token.routes.first['method']).to eq('GET')
+      expect(access_token.routes.first['path']).to eq('/test/this')
+    end
+  end
+  
+  ###############
+  # Class methods
+  ###############
+
+  describe '::fellow_dashboard_view(fellow)' do
+    let(:fellow) { create :fellow }
+    subject { AccessToken.fellow_dashboard_view(fellow) }
+    
+    it "generates access token with dashboard view only" do
+      expect(subject).to be_an(AccessToken)
+      expect(subject.routes).to eq([{'label' => 'view', 'method' => 'GET', 'path' => "/admin/fellows/#{fellow.id}"}])
+    end
+  end
+  
+  ##################
+  # Instance methods
+  ##################
+
+  describe 'route_for(label)' do
+    let(:route) { {'label' => 'tester', 'method' => 'GET', 'path' => '/test/this'} }
+    let(:access_token) { AccessToken.create routes: [route] }
+    
+    subject { access_token.route_for('tester') }
+
+    it { should eq(route) }
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe AccessToken, type: :model do
     
     it "generates access token with dashboard view only" do
       expect(subject).to be_an(AccessToken)
-      expect(subject.routes).to eq([{'label' => 'view', 'method' => 'GET', 'path' => "/admin/fellows/#{fellow.id}"}])
+      expect(subject.routes).to eq([{'label' => 'view', 'method' => 'GET', 'path' => "http://localhost:3011/admin/fellows/#{fellow.id}"}])
     end
   end
   

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -142,6 +142,22 @@ RSpec.describe AccessToken, type: :model do
     end
   end
   
+  describe '::update_profile(fellow)' do
+    let(:fellow) { create :fellow }
+    
+    subject { AccessToken.update_profile(fellow) }
+    
+    it { should be_an(AccessToken) }
+    
+    it "generates token with edit route" do
+      expect(subject.routes).to include({'label' => 'Edit Your Profile', 'method' => 'GET', 'path' => "http://localhost:3011/fellows/#{fellow.id}/edit"})
+    end
+    
+    it "generates token with update route" do
+      expect(subject.routes).to include({'label' => 'Update Your Profile', 'method' => 'PATCH', 'path' => "http://localhost:3011/fellows/#{fellow.id}"})
+    end
+  end
+  
   ##################
   # Instance methods
   ##################
@@ -173,22 +189,22 @@ RSpec.describe AccessToken, type: :model do
     subject { build :access_token, code: code, routes: [route_first, route_second] }
     
     it "returns true if any route matches method AND path, minus token parameter" do
-      request = double('request', original_url: "http://localhost:3011/second?token=#{code}", request_method: 'POST')
+      request = double('request', params: {token: code}, original_url: "http://localhost:3011/second?token=#{code}", request_method: 'POST')
       expect(subject.match?(request)).to be(true)
     end
     
     it "returns false if the token doesn't match" do
-      request = double('request', original_url: "http://localhost:3011/second?token=#{code}x", request_method: 'POST')
+      request = double('request', params: {token: code+'x'}, original_url: "http://localhost:3011/second?token=#{code}x", request_method: 'POST')
       expect(subject.match?(request)).to be(false)
     end
     
     it "returns false if request method doesn't match" do
-      request = double('request', original_url: "http://localhost:3011/second?token=#{code}", request_method: 'GET')
+      request = double('request', params: {token: code}, original_url: "http://localhost:3011/second?token=#{code}", request_method: 'GET')
       expect(subject.match?(request)).to be(false)
     end
     
     it "returns false if original url (minus token) doesn't match" do
-      request = double('request', original_url: "http://localhoster:3011/second?token=#{code}", request_method: 'POST')
+      request = double('request', params: {token: code}, original_url: "http://localhoster:3011/second?token=#{code}", request_method: 'POST')
       expect(subject.match?(request)).to be(false)
     end
   end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -117,9 +117,28 @@ RSpec.describe AccessToken, type: :model do
     let(:fellow) { create :fellow }
     subject { AccessToken.fellow_dashboard_view(fellow) }
     
+    it { should be_an(AccessToken) }
+    
     it "generates access token with dashboard view only" do
-      expect(subject).to be_an(AccessToken)
       expect(subject.routes).to eq([{'label' => 'view', 'method' => 'GET', 'path' => "http://localhost:3011/admin/fellows/#{fellow.id}"}])
+    end
+  end
+  
+  describe '::opportunity_invitation(fellow_opportunity)' do
+    let(:fellow) { create :fellow }
+    let(:opportunity) { create :opportunity }
+    let(:fellow_opportunity) { create :fellow_opportunity, fellow: fellow, opportunity: opportunity }
+    
+    subject { AccessToken.opportunity_invitation(fellow_opportunity) }
+    
+    it { should be_an(AccessToken) }
+    
+    it "generates access token with 'Interested' route" do
+      expect(subject.routes).to include({'label' => 'Interested', 'method' => 'GET', 'path' => "http://localhost:3011/candidates/#{fellow_opportunity.id}/status?update=Interested"})
+    end
+
+    it "generates access token with 'Not Interested' route" do
+      expect(subject.routes).to include({'label' => 'Not Interested', 'method' => 'GET', 'path' => "http://localhost:3011/candidates/#{fellow_opportunity.id}/status?update=Not+Interested"})
     end
   end
   

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -173,4 +173,19 @@ RSpec.describe AccessToken, type: :model do
       expect(subject.match?(request)).to be(false)
     end
   end
+  
+  describe 'path_with_token(label)' do
+    let(:access_token) { AccessToken.create code: code, routes: [route_one, route_two] }
+    let(:code) { '0000000000000000' }
+    let(:route_one) { {'label' => 'one', 'method' => 'GET', 'path' => '/test/one'} }
+    let(:route_two) { {'label' => 'two', 'method' => 'POST', 'path' => '/test/two'} }
+    
+    it "returns the path WITH token param" do
+      expect(access_token.path_with_token('two')).to eq("/test/two?token=#{code}")
+    end
+    
+    it "returns the default path with token param" do
+      expect(access_token.path_with_token).to eq("/test/one?token=#{code}")
+    end
+  end
 end

--- a/spec/models/fellow_opportunity_spec.rb
+++ b/spec/models/fellow_opportunity_spec.rb
@@ -24,4 +24,26 @@ RSpec.describe FellowOpportunity, type: :model do
     subject { create :fellow_opportunity }
     it { should validate_uniqueness_of(:fellow_id).scoped_to(:opportunity_id) }
   end
+  
+  ##################
+  # Instance methods
+  ##################
+
+  describe '#stage accessors' do
+    let(:stage_name) { 'stage name' }
+    let(:opportunity_stage) { create :opportunity_stage, name: stage_name }
+    let(:fellow_opportunity) { create :fellow_opportunity }
+    
+    before { fellow_opportunity; opportunity_stage }
+
+    it "returns the name of the opportunity stage" do
+      fellow_opportunity.opportunity_stage = opportunity_stage
+      expect(fellow_opportunity.stage).to eq(stage_name)
+    end
+
+    it "sets the opportunity_stage based on name" do
+      fellow_opportunity.stage = stage_name
+      expect(fellow_opportunity.reload.opportunity_stage).to eq(opportunity_stage)
+    end
+  end
 end

--- a/spec/routing/admin/candidates_routing_spec.rb
+++ b/spec/routing/admin/candidates_routing_spec.rb
@@ -1,0 +1,26 @@
+require_relative "../../rails_helper"
+
+RSpec.describe Admin::CandidatesController, type: :routing do
+  describe "routing" do
+    let(:opportunity_id) { '1001' }
+    let(:candidate_id) { '1002' }
+    
+    describe 'via opportunity' do
+      it "routes to #index" do
+        expect(:get => "/admin/opportunities/#{opportunity_id}/candidates").to route_to("admin/candidates#index", opportunity_id: opportunity_id)
+      end
+
+      it "routes to #create" do
+        expect(:post => "/admin/opportunities/#{opportunity_id}/candidates").to route_to("admin/candidates#create", opportunity_id: opportunity_id)
+      end
+    end
+    
+    it "routes to #update" do
+      expect(:put => "/admin/candidates/#{candidate_id}").to route_to("admin/candidates#update", id: candidate_id)
+    end
+    
+    it "routes to #destroy" do
+      expect(:delete => "/admin/candidates/#{candidate_id}").to route_to("admin/candidates#destroy", id: candidate_id)
+    end
+  end
+end

--- a/spec/routing/admin/coaches_routing_spec.rb
+++ b/spec/routing/admin/coaches_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::CoachesController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/cohort_fellows_routing_spec.rb
+++ b/spec/routing/admin/cohort_fellows_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::CohortFellowsController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/cohorts_routing_spec.rb
+++ b/spec/routing/admin/cohorts_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::CohortsController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/courses_routing_spec.rb
+++ b/spec/routing/admin/courses_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::CoursesController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/employers_routing_spec.rb
+++ b/spec/routing/admin/employers_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::EmployersController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/employment_statuses_routing_spec.rb
+++ b/spec/routing/admin/employment_statuses_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::EmploymentStatusesController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/fellow_opportunities_routing_spec.rb
+++ b/spec/routing/admin/fellow_opportunities_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::FellowOpportunitiesController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/fellows_routing_spec.rb
+++ b/spec/routing/admin/fellows_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::FellowsController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/industries_routing_spec.rb
+++ b/spec/routing/admin/industries_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::IndustriesController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/interests_routing_spec.rb
+++ b/spec/routing/admin/interests_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::InterestsController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/locations_routing_spec.rb
+++ b/spec/routing/admin/locations_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::LocationsController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/metros_routing_spec.rb
+++ b/spec/routing/admin/metros_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::MetrosController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/opportunities_routing_spec.rb
+++ b/spec/routing/admin/opportunities_routing_spec.rb
@@ -1,9 +1,7 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::OpportunitiesController, type: :routing do
   describe "routing" do
-    require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-    
     it "routes to #index" do
       expect(:get => "/admin/opportunities").to route_to("admin/opportunities#index")
     end

--- a/spec/routing/admin/opportunity_stages_routing_spec.rb
+++ b/spec/routing/admin/opportunity_stages_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::OpportunityStagesController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/sites_routing_spec.rb
+++ b/spec/routing/admin/sites_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe Admin::SitesController, type: :routing do
   describe "routing" do

--- a/spec/routing/admin/token_routing_spec.rb
+++ b/spec/routing/admin/token_routing_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require_relative "../../rails_helper"
 
 RSpec.describe TokenController, type: :routing do
   describe "routing" do

--- a/spec/routing/candidates_routing_spec.rb
+++ b/spec/routing/candidates_routing_spec.rb
@@ -1,26 +1,15 @@
 require "rails_helper"
 
-RSpec.describe Admin::CandidatesController, type: :routing do
+RSpec.describe CandidatesController, type: :routing do
   describe "routing" do
-    let(:opportunity_id) { '1001' }
-    let(:candidate_id) { '1002' }
+    let(:fellow_opportunity_id) { '1001' }
     
-    describe 'via opportunity' do
-      it "routes to #index" do
-        expect(:get => "/admin/opportunities/#{opportunity_id}/candidates").to route_to("admin/candidates#index", opportunity_id: opportunity_id)
-      end
-
-      it "routes to #create" do
-        expect(:post => "/admin/opportunities/#{opportunity_id}/candidates").to route_to("admin/candidates#create", opportunity_id: opportunity_id)
-      end
+    it "routes to #status" do
+      expect(:get => "/candidates/#{fellow_opportunity_id}/status?update=Interested").to route_to("candidates#status", fellow_opportunity_id: fellow_opportunity_id, update: 'Interested')
     end
     
-    it "routes to #update" do
-      expect(:put => "/admin/candidates/#{candidate_id}").to route_to("admin/candidates#update", id: candidate_id)
-    end
-    
-    it "routes to #destroy" do
-      expect(:delete => "/admin/candidates/#{candidate_id}").to route_to("admin/candidates#destroy", id: candidate_id)
+    it "routes to #status with token" do
+      expect(:get => "/candidates/#{fellow_opportunity_id}/status?update=Interested&token=123").to route_to("candidates#status", fellow_opportunity_id: fellow_opportunity_id, update: 'Interested', token: '123')
     end
   end
 end

--- a/spec/routing/fellow/profile_routing_spec.rb
+++ b/spec/routing/fellow/profile_routing_spec.rb
@@ -1,0 +1,22 @@
+require_relative "../../rails_helper"
+
+RSpec.describe Fellow::ProfilesController, type: :routing do
+  describe "routing" do
+
+    it "routes to #show" do
+      expect(:get => "/fellow/profile").to route_to("fellow/profiles#show")
+    end
+
+    it "routes to #edit" do
+      expect(:get => "/fellow/profile/edit").to route_to("fellow/profiles#edit")
+    end
+
+    it "routes to #update via PUT" do
+      expect(:put => "/fellow/profile").to route_to("fellow/profiles#update")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(:patch => "/fellow/profile").to route_to("fellow/profiles#update")
+    end
+  end
+end

--- a/spec/routing/fellows_routing_spec
+++ b/spec/routing/fellows_routing_spec
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe FellowsController, type: :routing do
+  describe "routing" do
+    let(:fellow_id) { '1001' }
+    
+    it "routes to #edit via GET" do
+      expect(:get => "/fellows/#{fellow_id}/edit").to route_to("fellows#edit", id: fellow_id)
+    end
+    
+    it "maps edit path" do
+      expect(edit_fellow_path(fellow_id)).to eq("/fellows/#{fellow_id}/edit")
+    end
+
+    it "routes to #update via PUT" do
+      expect(:put => "/fellows/#{fellow_id}").to route_to("fellows#update", id: fellow_id)
+    end
+    
+    it "maps update path" do
+      expect(fellow_path(fellow_id)).to eq("/fellows/#{fellow_id}")
+    end
+  end
+end

--- a/spec/routing/token_routing_spec.rb
+++ b/spec/routing/token_routing_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe TokenController, type: :routing do
+  describe "routing" do
+    it "routes to #show" do
+      expect(:get => "/token/1001").to route_to("token#show", id: '1001')
+    end
+  end
+end


### PR DESCRIPTION
Fellows can now update their profiles on one of two exciting ways:

* traditional login - there is now a link on their dashboard that allows them to edit only the parts of their profile we want. They can't edit their GPA, staff notes, efficacy score, etc.
* e-mail link - we now have the mechanisms in place to have a fellow update their profile without logging in, via e-mail link. There isn't currently a place in the app for admins to fire this off, since we don't know how we want to approach it. It may be another "auto-nag", possibly top priority since we can't perform good opportunity matches otherwise.

screencap via login: http://bit.ly/2AgBlTs
screencap via email: http://bit.ly/2JTRvS1

**Here's to learning more than we ever wanted about our fellows!**
![tmi](https://user-images.githubusercontent.com/12893/43210917-0037d226-8ff6-11e8-96f7-804a27ebbc8c.gif)

