### PR TITLE
Basic Candidate Notifier

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -5,83 +5,25 @@ class CandidateMailer < ApplicationMailer
     set_objects
     mail(to: @fellow.contact.email, subject: "You've been invited to apply for #{@opp.name}")
   end
+  
+  def notify
+    set_objects
 
-  def research_employer
-    set_stage 'research employer'
-    nag
-  end
+    @opportunity_stage = OpportunityStage.find_by(name: params[:stage_name])
+    @content = @opportunity_stage.content
 
-  def connect_with_employees
-    set_stage 'connect with employees'
-    nag
-  end
-
-  def customize_application_materials
-    set_stage 'customize application materials'
-    nag
-  end
-
-  def submit_application
-    set_stage 'submit application'
-    nag
-  end
-
-  def follow_up_after_application
-    set_stage 'follow up after application'
-    nag
-  end
-
-  def schedule_interview
-    set_stage 'schedule interview'
-    nag
-  end
-
-  def research_interview_process
-    set_stage 'research interview process'
-    nag
-  end
-
-  def practice_for_interview
-    set_stage 'practice for interview'
-    nag
-  end
-
-  def attend_interview
-    set_stage 'attend interview'
-    nag
-  end
-
-  def follow_up_after_interview
-    set_stage 'follow up after interview'
-    nag
-  end
-
-  def receive_offer
-    set_stage 'receive offer'
-    nag
-  end
-
-  def submit_counter_offer
-    set_stage 'submit counter-offer'
-    nag
-  end
-
-  def accept_offer
-    set_stage 'accept offer'
-    nag
+    mail(to: @fellow.contact.email, subject: "#{@opp.name}: #{@content['title']}")
   end
   
   private
   
-  def nag
+  def nag stage_name
+    set_stage stage_name
     set_objects
+
     @content = @opportunity_stage.content
 
     mail(to: @fellow.contact.email, subject: "#{@opp.name}: #{@content['title']}", template_name: 'notify')
-  end
-  
-  def set_stage stage_name
-    @opportunity_stage = OpportunityStage.find_by(name: stage_name)
   end
   
   def set_objects

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -20,7 +20,7 @@ class Fellow < ApplicationRecord
   belongs_to :employment_status
   belongs_to :user, optional: true
   
-  validates :first_name, :last_name, :employment_status_id, presence: true
+  validates :first_name, :last_name, presence: true
   
   validates :graduation_semester, inclusion: {in: (Course::VALID_SEMESTERS + [nil])}
   validates :graduation_year, numericality: {greater_than: 2010, less_than: 2050, allow_nil: true, only_integer: true}

--- a/app/models/fellow_opportunity.rb
+++ b/app/models/fellow_opportunity.rb
@@ -51,11 +51,7 @@ class FellowOpportunity < ApplicationRecord
       log stage_name
     end
     
-    update_active_status
-  end
-  
-  def update_active_status
-    self.update active: self.opportunity_stage.active_status
+    self.update active: self.opportunity_stage.active_status, last_contact_at: Time.now
   end
   
   def activate!

--- a/db/migrate/20180731011322_add_last_checkin_at_to_fellow_opportunities.rb
+++ b/db/migrate/20180731011322_add_last_checkin_at_to_fellow_opportunities.rb
@@ -1,0 +1,6 @@
+class AddLastCheckinAtToFellowOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :fellow_opportunities, :last_contact_at, :datetime
+    FellowOpportunity.update_all last_contact_at: Time.now
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_29_174435) do
+ActiveRecord::Schema.define(version: 2018_07_31_011322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 2018_07_29_174435) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.boolean "active"
+    t.datetime "last_contact_at"
     t.index ["active"], name: "index_fellow_opportunities_on_active"
     t.index ["deleted_at"], name: "index_fellow_opportunities_on_deleted_at"
     t.index ["fellow_id", "opportunity_id"], name: "index_fellow_opportunities_on_fellow_id_and_opportunity_id", unique: true

--- a/lib/candidate_notifier.rb
+++ b/lib/candidate_notifier.rb
@@ -1,0 +1,3 @@
+class CandidateNotifier
+  
+end

--- a/lib/candidate_notifier.rb
+++ b/lib/candidate_notifier.rb
@@ -1,3 +1,18 @@
-class CandidateNotifier
-  
+module CandidateNotifier
+  class << self
+    def send_notifications
+      FellowOpportunity.where("last_contact_at < ?", 3.days.ago).each do |candidate|
+        access_token = AccessToken.for(candidate)
+        
+        case candidate.stage
+        when 'respond to invitation'
+          CandidateMailer.with(access_token: access_token).respond_to_invitation.deliver_later
+        else
+          CandidateMailer.with(access_token: access_token, stage_name: candidate.stage).notify.deliver_later
+        end
+        
+        candidate.update last_contact_at: Time.now
+      end
+    end
+  end
 end

--- a/lib/candidate_notifier.rb
+++ b/lib/candidate_notifier.rb
@@ -1,7 +1,7 @@
 module CandidateNotifier
   class << self
     def send_notifications
-      FellowOpportunity.where("last_contact_at < ?", 3.days.ago).each do |candidate|
+      FellowOpportunity.active.where("last_contact_at < ?", 3.days.ago).each do |candidate|
         access_token = AccessToken.for(candidate)
         
         case candidate.stage

--- a/lib/tasks/candidate_mailer.rake
+++ b/lib/tasks/candidate_mailer.rake
@@ -1,0 +1,8 @@
+require 'candidate_notifier'
+
+namespace :candidate_mailer do
+  desc "Send notifications for any fellow opportunities that require it"
+  task send_notifications: :environment do
+    CandidateNotifier.send_notifications
+  end
+end

--- a/spec/lib/candidate_notifier_spec.rb
+++ b/spec/lib/candidate_notifier_spec.rb
@@ -2,4 +2,81 @@ require 'rails_helper'
 require 'candidate_notifier'
 
 RSpec.describe CandidateNotifier do
+  let(:access_token) { build :access_token }
+  
+  def delayed_mailer
+    return @delayed_mailer if defined?(@delayed_mailer)
+    
+    dj = Delayed::Job.where(queue: 'mailers').last
+    return @delayed_mailer = {} if dj.nil?
+
+    args = YAML.load(dj.handler).job_data['arguments']
+
+    @delayed_mailer = {
+      class: args[0],
+      view: args[1],
+      token: AccessToken.find(args[3]['access_token']['_aj_globalid'].split('/').last),
+      stage_name: args[3]['stage_name'],
+      params: args[3]
+    }
+  end
+  
+  def expect_mailer mailer_route, params
+    class_name, view = mailer_route.split('#')
+    expect(delayed_mailer[:class]).to eq(class_name)
+    expect(delayed_mailer[:view]).to eq(view)
+    expect(delayed_mailer[:token]).to eq(params[:access_token])
+    expect(delayed_mailer[:stage_name]).to eq(params[:stage_name])
+  end
+  
+  describe '::send_notifications' do
+    let(:access_token) { AccessToken.for(fellow_opportunity) }
+    let(:fellow_opportunity) { create :fellow_opportunity, fellow: fellow, opportunity: opportunity, opportunity_stage: opportunity_stage, last_contact_at: last_contact_at }
+    let(:fellow) { create :fellow }
+    let(:opportunity) { create :opportunity }
+    let(:opportunity_stage) { create :opportunity_stage, name: stage_name}
+    let(:stage_name) { 'research employer' }
+    
+    before do
+      access_token 
+      CandidateNotifier.send_notifications
+    end
+    
+    describe 'when last contact was more than three days ago' do
+      let(:last_contact_at) { 73.hours.ago }
+      
+      it "sends the 'notify' mailer, with the proper stage name" do
+        expect_mailer 'CandidateMailer#notify', access_token: access_token, stage_name: stage_name
+      end
+      
+      it "updates the last_contact_at field" do
+        expect(fellow_opportunity.reload.last_contact_at).to be_within(0.1).of(Time.now)
+      end
+    end
+    
+    describe 'when last contact was less than three days ago' do
+      let(:last_contact_at) { 71.hours.ago }
+      
+      it 'doesn\'t notify the candidate' do
+        expect(Delayed::Job.where(queue: 'mailers').count).to eq(0)
+      end
+      
+      it "DOES NOT update the last_contact_at field" do
+        expect(fellow_opportunity.reload.last_contact_at).to be_within(1).of(last_contact_at)
+      end
+    end
+    
+    describe 'when fellow has never responded' do
+      let(:last_contact_at) { 73.hours.ago }
+      let(:stage_name) { 'respond to invitation' }
+      
+      it "sends the respond_to_invitation mailer" do
+        expect_mailer 'CandidateMailer#respond_to_invitation', access_token: access_token
+      end
+      
+      it "updates the last_contact_at field" do
+        expect(fellow_opportunity.reload.last_contact_at).to be_within(0.1).of(Time.now)
+      end
+    end
+  end
 end

--- a/spec/lib/candidate_notifier_spec.rb
+++ b/spec/lib/candidate_notifier_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+require 'candidate_notifier'
+
+RSpec.describe CandidateNotifier do
+end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   let(:opportunity_stage) { create :opportunity_stage, name: stage_name }
   let(:stage_name) { view.to_s.gsub('_', ' ') }
 
-  let(:mail) { CandidateMailer.with(access_token: access_token).send(view) }
+  let(:mail) { CandidateMailer.with(access_token: access_token, stage_name: stage_name).send(view) }
   
   class << self
     def expect_headers subject
@@ -34,171 +34,177 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
   
   describe 'respond to invitation' do
-    let(:view) { :respond_to_invitation }
+    let(:stage_name) { 'respond to invitation' }
     
+    let(:mail) { CandidateMailer.with(access_token: access_token).respond_to_invitation }
+
     expect_headers "You've been invited to apply for New Opportunity"
     expect_content 'New Opportunity'
 
     expect_status_link 'respond to invitation', 'research employer'
     expect_status_link 'respond to invitation', 'fellow decline'
   end
+  
+  describe 'via notify mailer' do
+    let(:view) { :notify }
+    let(:mail) { CandidateMailer.with(access_token: access_token, stage_name: stage_name).notify }
 
-  describe 'research employer' do
-    let(:view) { :research_employer }
+    describe 'research employer' do
+      let(:stage_name) { 'research employer' }
 
-    expect_headers "New Opportunity: Research this Employer"
-    expect_content 'Have you researched'
+      expect_headers "New Opportunity: Research this Employer"
+      expect_content 'Have you researched'
 
-    expect_status_link 'research employer', 'next'
-    expect_status_link 'research employer', 'no change'
-    expect_status_link 'research employer', 'skip'
-    expect_status_link 'research employer', 'fellow declined'
-  end
+      expect_status_link 'research employer', 'next'
+      expect_status_link 'research employer', 'no change'
+      expect_status_link 'research employer', 'skip'
+      expect_status_link 'research employer', 'fellow declined'
+    end
 
-  describe 'connect with employees' do
-    let(:view) { :connect_with_employees }
+    describe 'connect with employees' do
+      let(:stage_name) { 'connect with employees' }
 
-    expect_headers "New Opportunity: Connect with Current Employees"
-    expect_content "Have you networked"
+      expect_headers "New Opportunity: Connect with Current Employees"
+      expect_content "Have you networked"
 
-    expect_status_link 'connect with employees', 'next'
-    expect_status_link 'connect with employees', 'no change'
-    expect_status_link 'connect with employees', 'skip'
-    expect_status_link 'connect with employees', 'fellow declined'
-  end
+      expect_status_link 'connect with employees', 'next'
+      expect_status_link 'connect with employees', 'no change'
+      expect_status_link 'connect with employees', 'skip'
+      expect_status_link 'connect with employees', 'fellow declined'
+    end
 
-  describe 'customize application materials' do
-    let(:view) { :customize_application_materials }
+    describe 'customize application materials' do
+      let(:stage_name) { 'customize application materials' }
 
-    expect_headers "New Opportunity: Customize Your Application Materials"
-    expect_content "Have you customized"
+      expect_headers "New Opportunity: Customize Your Application Materials"
+      expect_content "Have you customized"
 
-    expect_status_link 'customize application materials', 'next'
-    expect_status_link 'customize application materials', 'no change'
-    expect_status_link 'customize application materials', 'skip'
-    expect_status_link 'customize application materials', 'fellow declined'
-  end
+      expect_status_link 'customize application materials', 'next'
+      expect_status_link 'customize application materials', 'no change'
+      expect_status_link 'customize application materials', 'skip'
+      expect_status_link 'customize application materials', 'fellow declined'
+    end
 
-  describe 'submit application' do
-    let(:view) { :submit_application }
+    describe 'submit application' do
+      let(:stage_name) { 'submit application' }
 
-    expect_headers "New Opportunity: Submit Your Application"
-    expect_content "Have you submitted"
+      expect_headers "New Opportunity: Submit Your Application"
+      expect_content "Have you submitted"
 
-    expect_status_link 'submit application', 'next'
-    expect_status_link 'submit application', 'no change'
-    expect_status_link 'submit application', 'skip'
-    expect_status_link 'submit application', 'fellow declined'
-  end
+      expect_status_link 'submit application', 'next'
+      expect_status_link 'submit application', 'no change'
+      expect_status_link 'submit application', 'skip'
+      expect_status_link 'submit application', 'fellow declined'
+    end
 
-  describe 'follow up after application' do
-    let(:view) { :follow_up_after_application }
+    describe 'follow up after application' do
+      let(:stage_name) { 'follow up after application' }
 
-    expect_headers "New Opportunity: Follow Up on Your Application"
-    expect_content "Have you followed"
+      expect_headers "New Opportunity: Follow Up on Your Application"
+      expect_content "Have you followed"
 
-    expect_status_link 'follow up after application', 'next'
-    expect_status_link 'follow up after application', 'no change'
-    expect_status_link 'follow up after application', 'skip'
-    expect_status_link 'follow up after application', 'fellow declined'
-    expect_status_link 'follow up after application', 'employer declined'
-  end
+      expect_status_link 'follow up after application', 'next'
+      expect_status_link 'follow up after application', 'no change'
+      expect_status_link 'follow up after application', 'skip'
+      expect_status_link 'follow up after application', 'fellow declined'
+      expect_status_link 'follow up after application', 'employer declined'
+    end
 
-  describe 'schedule interview' do
-    let(:view) { :schedule_interview }
+    describe 'schedule interview' do
+      let(:stage_name) { 'schedule interview' }
 
-    expect_headers "New Opportunity: Schedule an Interview"
-    expect_content "Have you scheduled"
+      expect_headers "New Opportunity: Schedule an Interview"
+      expect_content "Have you scheduled"
 
-    expect_status_link 'schedule interview', 'next'
-    expect_status_link 'schedule interview', 'no change'
-    expect_status_link 'schedule interview', 'skip'
-    expect_status_link 'schedule interview', 'fellow declined'
-    expect_status_link 'schedule interview', 'employer declined'
-  end
+      expect_status_link 'schedule interview', 'next'
+      expect_status_link 'schedule interview', 'no change'
+      expect_status_link 'schedule interview', 'skip'
+      expect_status_link 'schedule interview', 'fellow declined'
+      expect_status_link 'schedule interview', 'employer declined'
+    end
 
-  describe 'research interview process' do
-    let(:view) { :research_interview_process }
+    describe 'research interview process' do
+      let(:stage_name) { 'research interview process' }
 
-    expect_headers "New Opportunity: Research the Interview Process"
-    expect_content "Have you researched"
+      expect_headers "New Opportunity: Research the Interview Process"
+      expect_content "Have you researched"
 
-    expect_status_link 'research interview process', 'next'
-    expect_status_link 'research interview process', 'no change'
-    expect_status_link 'research interview process', 'skip'
-    expect_status_link 'research interview process', 'fellow declined'
-  end
+      expect_status_link 'research interview process', 'next'
+      expect_status_link 'research interview process', 'no change'
+      expect_status_link 'research interview process', 'skip'
+      expect_status_link 'research interview process', 'fellow declined'
+    end
 
-  describe 'practice for interview' do
-    let(:view) { :practice_for_interview }
+    describe 'practice for interview' do
+      let(:stage_name) { 'practice for interview'}
 
-    expect_headers "New Opportunity: Practice for Your Interview"
-    expect_content "Have you practiced"
+      expect_headers "New Opportunity: Practice for Your Interview"
+      expect_content "Have you practiced"
 
-    expect_status_link 'practice for interview', 'next'
-    expect_status_link 'practice for interview', 'no change'
-    expect_status_link 'practice for interview', 'skip'
-    expect_status_link 'practice for interview', 'fellow declined'
-  end
+      expect_status_link 'practice for interview', 'next'
+      expect_status_link 'practice for interview', 'no change'
+      expect_status_link 'practice for interview', 'skip'
+      expect_status_link 'practice for interview', 'fellow declined'
+    end
 
-  describe 'attend interview' do
-    let(:view) { :attend_interview }
+    describe 'attend interview' do
+      let(:stage_name) { 'attend interview' }
 
-    expect_headers "New Opportunity: Ace Your Interview!"
-    expect_content "Have you attended"
+      expect_headers "New Opportunity: Ace Your Interview!"
+      expect_content "Have you attended"
 
-    expect_status_link 'attend interview', 'next'
-    expect_status_link 'attend interview', 'no change'
-    expect_status_link 'attend interview', 'skip'
-    expect_status_link 'attend interview', 'fellow declined'
-  end
+      expect_status_link 'attend interview', 'next'
+      expect_status_link 'attend interview', 'no change'
+      expect_status_link 'attend interview', 'skip'
+      expect_status_link 'attend interview', 'fellow declined'
+    end
 
-  describe 'follow up after interview' do
-    let(:view) { :follow_up_after_interview }
+    describe 'follow up after interview' do
+      let(:stage_name) { 'follow up after interview' }
 
-    expect_headers "New Opportunity: Follow Up After Your Interview"
-    expect_content "Have you followed"
+      expect_headers "New Opportunity: Follow Up After Your Interview"
+      expect_content "Have you followed"
 
-    expect_status_link 'follow up after interview', 'next'
-    expect_status_link 'follow up after interview', 'no change'
-    expect_status_link 'follow up after interview', 'skip'
-    expect_status_link 'follow up after interview', 'fellow declined'
-    expect_status_link 'follow up after interview', 'employer declined'
-  end
+      expect_status_link 'follow up after interview', 'next'
+      expect_status_link 'follow up after interview', 'no change'
+      expect_status_link 'follow up after interview', 'skip'
+      expect_status_link 'follow up after interview', 'fellow declined'
+      expect_status_link 'follow up after interview', 'employer declined'
+    end
 
-  describe 'receive offer' do
-    let(:view) { :receive_offer }
+    describe 'receive offer' do
+      let(:stage_name) { 'receive offer' }
 
-    expect_headers "New Opportunity: Look for an Offer!"
-    expect_content "Have you received"
+      expect_headers "New Opportunity: Look for an Offer!"
+      expect_content "Have you received"
 
-    expect_status_link 'receive offer', 'next'
-    expect_status_link 'receive offer', 'no change'
-    expect_status_link 'receive offer', 'fellow declined'
-    expect_status_link 'receive offer', 'employer declined'
-  end
+      expect_status_link 'receive offer', 'next'
+      expect_status_link 'receive offer', 'no change'
+      expect_status_link 'receive offer', 'fellow declined'
+      expect_status_link 'receive offer', 'employer declined'
+    end
 
-  describe 'submit counter-offer' do
-    let(:view) { :submit_counter_offer }
-    let(:stage_name) { 'submit counter-offer' }
+    describe 'submit counter-offer' do
+      let(:stage_name) { 'submit counter-offer' }
 
-    expect_headers "New Opportunity: Consider a Counter Offer"
-    expect_content "Have you submitted"
+      expect_headers "New Opportunity: Consider a Counter Offer"
+      expect_content "Have you submitted"
 
-    expect_status_link 'submit counter-offer', 'receive offer'
-    expect_status_link 'submit counter-offer', 'no change'
-    expect_status_link 'submit counter-offer', 'fellow accepted'
-    expect_status_link 'submit counter-offer', 'fellow declined'
-  end
+      expect_status_link 'submit counter-offer', 'receive offer'
+      expect_status_link 'submit counter-offer', 'no change'
+      expect_status_link 'submit counter-offer', 'fellow accepted'
+      expect_status_link 'submit counter-offer', 'fellow declined'
+    end
 
-  describe 'accept offer' do
-    let(:view) { :accept_offer }
+    describe 'accept offer' do
+      let(:stage_name) { 'accept offer' }
 
-    expect_headers "New Opportunity: Accept Your Offer!"
-    expect_content "Have you accepted"
+      expect_headers "New Opportunity: Accept Your Offer!"
+      expect_content "Have you accepted"
 
-    expect_status_link 'accept offer', 'next'
-    expect_status_link 'accept offer', 'no change'
-    expect_status_link 'accept offer', 'fellow declined'
+      expect_status_link 'accept offer', 'next'
+      expect_status_link 'accept offer', 'no change'
+      expect_status_link 'accept offer', 'fellow declined'
+    end
   end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -5,55 +5,55 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
   
   def step_02_research_employer
-    CandidateMailer.with(access_token: access_token).research_employer
+    CandidateMailer.with(access_token: access_token, stage_name: 'research employer').notify
   end
   
   def step_03_connect_with_employees
-    CandidateMailer.with(access_token: access_token).connect_with_employees
+    CandidateMailer.with(access_token: access_token, stage_name: 'connect with employees').notify
   end
   
   def step_04_customize_application_materials
-    CandidateMailer.with(access_token: access_token).customize_application_materials
+    CandidateMailer.with(access_token: access_token, stage_name: 'customize application materials').notify
   end
   
   def step_05_submit_application
-    CandidateMailer.with(access_token: access_token).submit_application
+    CandidateMailer.with(access_token: access_token, stage_name: 'submit application').notify
   end
   
   def step_06_follow_up_after_application
-    CandidateMailer.with(access_token: access_token).follow_up_after_application
+    CandidateMailer.with(access_token: access_token, stage_name: 'follow up after application').notify
   end
   
   def step_07_schedule_interview
-    CandidateMailer.with(access_token: access_token).schedule_interview
+    CandidateMailer.with(access_token: access_token, stage_name: 'schedule interview').notify
   end
   
   def step_08_research_interview_process
-    CandidateMailer.with(access_token: access_token).research_interview_process
+    CandidateMailer.with(access_token: access_token, stage_name: 'research interview process').notify
   end
   
   def step_09_practice_for_interview
-    CandidateMailer.with(access_token: access_token).practice_for_interview
+    CandidateMailer.with(access_token: access_token, stage_name: 'practice for interview').notify
   end
   
   def step_10_attend_interview
-    CandidateMailer.with(access_token: access_token).attend_interview
+    CandidateMailer.with(access_token: access_token, stage_name: 'attend interview').notify
   end
   
   def step_11_follow_up_after_interview
-    CandidateMailer.with(access_token: access_token).follow_up_after_interview
+    CandidateMailer.with(access_token: access_token, stage_name: 'follow up after interview').notify
   end
   
   def step_12_receive_offer
-    CandidateMailer.with(access_token: access_token).receive_offer
+    CandidateMailer.with(access_token: access_token, stage_name: 'receive offer').notify
   end
   
   def step_13_submit_counter_offer
-    CandidateMailer.with(access_token: access_token).submit_counter_offer
+    CandidateMailer.with(access_token: access_token, stage_name: 'submit counter-offer').notify
   end
   
   def step_14_accept_offer
-    CandidateMailer.with(access_token: access_token).accept_offer
+    CandidateMailer.with(access_token: access_token, stage_name: 'accept offer').notify
   end
   
   private

--- a/spec/models/fellow_opportunity_spec.rb
+++ b/spec/models/fellow_opportunity_spec.rb
@@ -105,6 +105,10 @@ RSpec.describe FellowOpportunity, type: :model do
       it "creates a log record when stage is set" do
         expect_log(name_second)
       end
+      
+      it "updates last_contact_at timestamp" do
+        expect(fellow_opportunity.last_contact_at).to be_within(0.1).of(Time.now)
+      end
     
       describe 'with special status "no change"' do
         let(:name_update) { 'no change' }

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Fellow, type: :model do
   #############
 
   def self.required_attributes
-    [:first_name, :last_name, :employment_status_id]
+    [:first_name, :last_name]
   end
   
   required_attributes.each do |attribute|


### PR DESCRIPTION
This PR includes a basic candidate notifier module that sends the appropriate message for the current status, if our last contact with the candidate is more than three days ago.  "Last contact" is the most recent of two things:

* fellow updates us on their status, even if they just say "no change". It's like hitting the snooze button.
* we've sent them a notification about this opportunity.

Only sends notification if the given candidate's status for this opportunity is "active". 

There is a rake task which can be run daily, or even multiple times a day. We can pick the best times of day to notify candidates, and this tool will send out notification to those opportunities that have "ripened" since the last notification.

**Let's do this!**
![send-notifications](https://user-images.githubusercontent.com/12893/43432285-a78716a0-9437-11e8-94e9-283add66e809.gif)
