### PR TITLE
Better Fellow vs Admin Identification

### DIFF
--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -37,7 +37,9 @@ class Fellow < ApplicationRecord
       CSV.new(contents, headers: true, skip_lines: /(Anticipated Graduation|STUDENT INFORMATION)/).each do |data|
         cohort = Site.cohort_for data['Braven class']
 
-        next if cohort.nil?
+        if cohort.nil?
+          puts "COULD NOT FIND A COHORT MATCH FOR #{data['Braven class'].inspect} '#{data['First Name']} #{data['Last Name']}'"
+        end
 
         attributes = {
           first_name: data['First Name'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
 
   def attempt_admin_set
     return if email.nil?
+    return if FellowUserMatcher.match?(email)
     
     domain = email.split('@').last
     self.is_admin = ADMIN_DOMAIN_WHITELIST.include?(domain)

--- a/lib/fellow_user_matcher.rb
+++ b/lib/fellow_user_matcher.rb
@@ -9,5 +9,9 @@ class FellowUserMatcher
         user.update is_fellow: true
       end
     end
+    
+    def match? email
+      Fellow.includes(:contact).where(contacts: {email: email}).count > 0
+    end
   end
 end

--- a/spec/lib/fellow_user_matcher_spec.rb
+++ b/spec/lib/fellow_user_matcher_spec.rb
@@ -3,6 +3,7 @@ require 'fellow_user_matcher'
 
 RSpec.describe FellowUserMatcher do
   let(:email) { 'matching@example.com' }
+  let(:email_nomatch) { 'nonmatching@example.com' }
   
   let(:user_match) { create :user, is_fellow: false, email: email }
   let(:user_nomatch) { create :user, is_fellow: false }
@@ -17,9 +18,23 @@ RSpec.describe FellowUserMatcher do
     contact
   end
   
-  subject { FellowUserMatcher.match(email) }
+  describe '::match(email)?' do
+    subject { FellowUserMatcher.match?(this_email) }
+    
+    describe 'when email matches a fellow' do
+      let(:this_email) { email }
+      it { should be(true) }
+    end
+    
+    describe 'when email doesn\'t match a fellow' do
+      let(:this_email) { email_nomatch }
+      it { should be(false) }
+    end
+  end
   
   describe "::match(email)" do
+    subject { FellowUserMatcher.match(email) }
+
     before { subject }
     
     it "associates a fellow to a matching user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe User, type: :model do
       expect(user.reload.is_admin?).to be(true)
     end
     
+    it "leaves the user as not admin if they can be a fellow" do
+      email = "test@#{admin_domain}"
+      
+      allow(FellowUserMatcher).to receive(:match?).with(email).and_return(true)
+      user = create :user, email: email
+
+      expect(user.reload.is_admin?).to be(false)
+    end
+    
     it "leaves the user as not admin if the e-mail domain is not in the whitelist" do
       user = create :user, email: "test@not.#{admin_domain}"
       expect(user.reload.is_admin?).to be(false)


### PR DESCRIPTION
This change does a couple things:

* a user, even with a bebraven.org e-mail, won't be set to admin if that e-mail can be matched to an existing fellow record.
* slightly better logging of skipped csv rows on fellow import

Sorry, this is a quick PR - all business!
![screen shot 2018-08-02 at 11 42 01 am](https://user-images.githubusercontent.com/12893/43597951-2689f27a-9649-11e8-98a8-aeadbaed5a47.png)
