### PR TITLE
Career Tracker Steps

### DIFF
--- a/app/assets/javascripts/fellow/home.coffee
+++ b/app/assets/javascripts/fellow/home.coffee
@@ -5,3 +5,14 @@
 $(document).on "turbolinks:load",  ->
   $('input.career[type=checkbox]').click (event) ->
     $(event.target).form().submit()
+    
+  $('form.career-tracker-form').submit (event) ->
+    event.preventDefault()
+    
+    $.ajax({
+      type: 'POST',
+      url: this.action,
+      data: $(this).serialize(),
+      success: () ->
+        console.log('career steps have been updated.')
+    })

--- a/app/assets/javascripts/fellow/home.coffee
+++ b/app/assets/javascripts/fellow/home.coffee
@@ -1,0 +1,7 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/
+
+$(document).on "turbolinks:load",  ->
+  $('input.career[type=checkbox]').click (event) ->
+    $(event.target).form().submit()

--- a/app/controllers/fellow/home_controller.rb
+++ b/app/controllers/fellow/home_controller.rb
@@ -1,9 +1,14 @@
 class Fellow::HomeController < ApplicationController
   before_action :authenticate_user!
   before_action :ensure_fellow!
+  before_action :set_fellow, only: [:welcome, :career]
   
   def welcome
-    set_fellow
+  end
+  
+  def career
+    @fellow.completed_career_steps = params[:career_steps]
+    redirect_to fellow_home_welcome_path
   end
   
   def new_opportunity

--- a/app/controllers/fellow/home_controller.rb
+++ b/app/controllers/fellow/home_controller.rb
@@ -8,7 +8,7 @@ class Fellow::HomeController < ApplicationController
   
   def career
     @fellow.completed_career_steps = params[:career_steps]
-    redirect_to fellow_home_welcome_path
+    # redirect_to fellow_home_welcome_path
   end
   
   def new_opportunity

--- a/app/models/career_step.rb
+++ b/app/models/career_step.rb
@@ -2,4 +2,8 @@ class CareerStep < ApplicationRecord
   belongs_to :fellow
   
   validates :name, :description, presence: true
+  
+  scope :completed, -> { where(completed: true) }
+  
+  default_scope { order(position: :asc) }
 end

--- a/app/models/career_step.rb
+++ b/app/models/career_step.rb
@@ -1,0 +1,5 @@
+class CareerStep < ApplicationRecord
+  belongs_to :fellow
+  
+  validates :name, :description, presence: true
+end

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -14,6 +14,7 @@ class Fellow < ApplicationRecord
   has_many :cohort_fellows, dependent: :destroy
   has_many :cohorts, through: :cohort_fellows
   has_many :fellow_opportunities
+  has_many :career_steps
 
   taggable :industries, :interests, :majors, :industry_interests, :metros
   
@@ -30,6 +31,7 @@ class Fellow < ApplicationRecord
   validates :efficacy_score, numericality: {greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0, allow_nil: true}
   
   before_create :generate_key
+  after_create :generate_career_steps
   after_save :attempt_fellow_match, if: :missing_user?
   
   class << self
@@ -144,6 +146,12 @@ class Fellow < ApplicationRecord
     
     hash = Digest::MD5.hexdigest([first_name, last_name, graduation_year, unique_count].join('-'))[0,4]
     self.key = [first_name[0].upcase, last_name[0].upcase, ((graduation_year || 0) % 100), hash].join('').upcase
+  end
+  
+  def generate_career_steps
+    YAML.load(File.read("#{Rails.root}/config/career_steps.yml")).each_with_index do |step, position|
+      career_steps.create position: position, name: step['name'], description: step['description']
+    end
   end
   
   def missing_user?

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -138,6 +138,15 @@ class Fellow < ApplicationRecord
     end
   end
   
+  def completed_career_steps
+    career_steps.completed.pluck(:position)
+  end
+  
+  def completed_career_steps= positions
+    career_steps.update_all(completed: false)
+    career_steps.where(position: positions).update_all(completed: true)
+  end
+  
   private
   
   def generate_key

--- a/app/views/fellow/home/welcome.html.erb
+++ b/app/views/fellow/home/welcome.html.erb
@@ -1,24 +1,27 @@
 <h1><%= @fellow.first_name %>&rsquo;s Career Dashboard</h1>
 
+<%= link_to 'View profile details', fellow_profile_path %>
+
 <h2>Career Progress</h2>
+
 <p>Complete these important milestones to set yourself up for successful job hunting. Most of the items can be completed as part of the Braven Accelerator.</p>
+
 <div id="career-tracker">
-  <div class="tracker-item"><input id="career-item-01" type="checkbox" checked><label for="career-item-01"><h4>1</h4><p>I know my strengths and values and can communicate my story</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-02" type="checkbox" checked><label for="career-item-02"><h4>2</h4><p>I understand what career-accelerating means and what career paths can look like</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-03" type="checkbox" checked><label for="career-item-03"><h4>3</h4><p>I have a career roadmap with professional goals and a plan</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-04" type="checkbox"><label for="career-item-04"><h4>4</h4><p>My resume is strong and ready to send to potential employers</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-05" type="checkbox"><label for="career-item-05"><h4>5</h4><p>My LinkedIn profile is updated and professional</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-06" type="checkbox"><label for="career-item-06"><h4>6</h4><p>My social media is scrubbed of content I don’t want potential employers to see</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-07" type="checkbox"><label for="career-item-07"><h4>7</h4><p>I know my elevator pitch like the back of my hand</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-08" type="checkbox"><label for="career-item-08"><h4>8</h4><p>I have a networking strategy and a system for keeping track of opportunities and people I meet</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-09" type="checkbox"><label for="career-item-09"><h4>9</h4><p>I’ve had informational interviews with professionals in my desired career field</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-10" type="checkbox"><label for="career-item-10"><h4>10</h4><p>I am ready to ace a job interview</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-11" type="checkbox"><label for="career-item-11"><h4>11</h4><p>I've reflected on what I want to look for next, and I have researched the field</p></label><a href="#">How to do this</a></div>
-  <div class="tracker-item"><input id="career-item-12" type="checkbox"><label for="career-item-12"><h4>12</h4><p>I've made a short list of my preferred positions and/or employers</p></label><a href="#">How to do this</a></div>
+  <div class="tracker-item start"><h4>START</h4><p class="big-symbol">&#10132;</p></div>
+  <% @fellow.career_steps.order(position: 'asc').each do |career_step| %>
+    <div class="tracker-item">
+      <input id="career-item-<%= sprintf('%02d', career_step.position + 1) %>" type="checkbox" <%= career_step.completed ? 'checked' : '' %>>
+      <label for="career-item-01">
+        <h4><%= career_step.position + 1 %></h4>
+        <p><%= career_step.description %></p>
+      </label></div>
+  <% end %>
 </div>
+
 <h2>Job Hunter</h2>
+
 <p>This tool shows career opportunities for selected Braven Fellows from our employer partners. You can get more relevant opportunities by keeping <%= link_to 'your profile', fellow_profile_path %> up to date.</p>
-<h3>Active Opportunities</h3>
+
 <% if @fellow.fellow_opportunities.empty? %>
   <p>None at this time. You'll be notified when new ones come up that match <%= link_to 'your profile', fellow_profile_path %>.</p>
 <% else %>

--- a/app/views/fellow/home/welcome.html.erb
+++ b/app/views/fellow/home/welcome.html.erb
@@ -6,17 +6,22 @@
 
 <p>Complete these important milestones to set yourself up for successful job hunting. Most of the items can be completed as part of the Braven Accelerator.</p>
 
-<div id="career-tracker">
-  <div class="tracker-item start"><h4>START</h4><p class="big-symbol">&#10132;</p></div>
-  <% @fellow.career_steps.order(position: 'asc').each do |career_step| %>
-    <div class="tracker-item">
-      <input id="career-item-<%= sprintf('%02d', career_step.position + 1) %>" type="checkbox" <%= career_step.completed ? 'checked' : '' %>>
-      <label for="career-item-01">
-        <h4><%= career_step.position + 1 %></h4>
-        <p><%= career_step.description %></p>
-      </label></div>
-  <% end %>
-</div>
+<%= form_tag fellow_home_career_path, class: 'career-tracker-form' do %>
+  <div id="career-tracker">
+    <div class="tracker-item start"><h4>START</h4><p class="big-symbol">&#10132;</p></div>
+    <% @fellow.career_steps.order(position: 'asc').each do |career_step| %>
+      <% label = "career-item-#{sprintf('%02d', career_step.position + 1)}" %>
+    
+      <div class="tracker-item">
+        <%= check_box_tag('career_steps[]', career_step.position, career_step.completed, id: label, class: 'career') %>
+      
+        <label for="<%= label %>">
+          <h4><%= career_step.position + 1 %></h4>
+          <p><%= career_step.description %></p>
+        </label></div>
+    <% end %>
+  </div>
+<% end %>
 
 <h2>Job Hunter</h2>
 

--- a/config/career_steps.yml
+++ b/config/career_steps.yml
@@ -1,0 +1,36 @@
+-
+  name: strengths
+  description: "I know my strengths and values and can communicate my story"
+-
+  name: accelerating
+  description: "I understand what career-accelerating means and what career paths can look like"
+-
+  name: roadmap
+  description: "I have a career roadmap with professional goals and a plan"
+-
+  name: resume
+  description: "My resume is strong and ready to send to potential employers"
+-
+  name: linkedin
+  description: "My LinkedIn profile is updated and professional"
+-
+  name: social media
+  description: "My social media is scrubbed of content I don’t want potential employers to see"
+-
+  name: elevator pitch
+  description: "I know my elevator pitch like the back of my hand"
+-
+  name: networking
+  description: "I have a networking strategy and a system for keeping track of opportunities and people I meet"
+-
+  name: interviews
+  description: "I’ve had informational interviews with professionals in my desired career field"
+-
+  name: ready
+  description: "I am ready to ace a job interview"
+-
+  name: reflection
+  description: "I've reflected on what I want to look for next and researched the field"
+-
+  name: employers
+  description: "I've made a shortlist of positions and/or employers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   namespace :fellow do
     get 'home/welcome'
+    post 'home/career'
     
     resource :profile, only: [:show, :edit, :update]
     resources :opportunities, only: [:show, :update]

--- a/db/migrate/20180808193539_create_career_steps.rb
+++ b/db/migrate/20180808193539_create_career_steps.rb
@@ -1,0 +1,14 @@
+class CreateCareerSteps < ActiveRecord::Migration[5.2]
+  def change
+    create_table :career_steps do |t|
+      t.integer :fellow_id
+      t.integer :position
+      t.string :name
+      t.string :description
+      t.boolean :completed, default: false
+
+      t.timestamps
+    end
+    add_index :career_steps, :fellow_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_07_212654) do
+ActiveRecord::Schema.define(version: 2018_08_08_193539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,17 @@ ActiveRecord::Schema.define(version: 2018_08_07_212654) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["candidate_id"], name: "index_candidate_logs_on_candidate_id"
+  end
+
+  create_table "career_steps", force: :cascade do |t|
+    t.integer "fellow_id"
+    t.integer "position"
+    t.string "name"
+    t.string "description"
+    t.boolean "completed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fellow_id"], name: "index_career_steps_on_fellow_id"
   end
 
   create_table "coaches", force: :cascade do |t|

--- a/spec/controllers/fellow/home_controller_spec.rb
+++ b/spec/controllers/fellow/home_controller_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe Fellow::HomeController, type: :controller do
       expect(response.status).to eq(200) #have_http_status(:success)
     end
   end
+  
+  describe 'POST career' do
+    it "updates career steps" do
+      post :career, params: {career_steps: ['1', '3', '5']}
+      expect(fellow.completed_career_steps).to eq([1,3,5])
+    end
+    
+    it "redirects to #welcome" do
+      post :career, params: {career_steps: ['1', '3', '5']}
+      expect(response).to redirect_to(fellow_home_welcome_path)
+    end
+  end
 end

--- a/spec/controllers/fellow/home_controller_spec.rb
+++ b/spec/controllers/fellow/home_controller_spec.rb
@@ -29,10 +29,5 @@ RSpec.describe Fellow::HomeController, type: :controller do
       post :career, params: {career_steps: ['1', '3', '5']}
       expect(fellow.completed_career_steps).to eq([1,3,5])
     end
-    
-    it "redirects to #welcome" do
-      post :career, params: {career_steps: ['1', '3', '5']}
-      expect(response).to redirect_to(fellow_home_welcome_path)
-    end
   end
 end

--- a/spec/factories/career_steps.rb
+++ b/spec/factories/career_steps.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :career_step do
+    name 'Name'
+    description 'Description'
+    
+    association :fellow
+  end
+end

--- a/spec/models/career_step_spec.rb
+++ b/spec/models/career_step_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe CareerStep, type: :model do
+  let(:career_step) { create :career_step, fellow: fellow }
+  let(:fellow) { create :fellow }
+
+  ##############
+  # Associations
+  ##############
+
+  it { should belong_to :fellow }
+
+  #############
+  # Validations
+  #############
+
+  [:name, :description].each do |attribute|
+    it { should validate_presence_of(attribute) }
+  end
+end

--- a/spec/models/career_step_spec.rb
+++ b/spec/models/career_step_spec.rb
@@ -17,4 +17,21 @@ RSpec.describe CareerStep, type: :model do
   [:name, :description].each do |attribute|
     it { should validate_presence_of(attribute) }
   end
+  
+  ########
+  # Scopes
+  ########
+
+  describe 'completed' do
+    let(:fellow) { create :fellow }
+    let(:completed) { create :career_step, fellow: fellow, completed: true }
+    let(:not_completed) { create :career_step, fellow: fellow, completed: false }
+    
+    before { completed; not_completed }
+    
+    subject { CareerStep.completed }
+    
+    it { should include(completed) }
+    it { should_not include(not_completed) }
+  end
 end

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -361,4 +361,31 @@ RSpec.describe Fellow, type: :model do
     it { expect(subject[11].name).to eq('employers') }
     it { expect(subject[11].description).to eq("I've made a shortlist of positions and/or employers") }
   end
+  
+  describe '#completed_career_steps' do
+    let(:completed_positions) { [1,3,5] }
+    
+    subject { fellow.completed_career_steps }
+    
+    before do
+      fellow.career_steps.where(position: completed_positions).update_all(completed: true)
+    end
+    
+    it "returns active step ids" do
+      expect(subject).to eq(completed_positions)
+    end
+  end
+  
+  describe '#active_career_steps=' do
+    let(:completed_positions) { [1,3,5] }
+    
+    before do
+      fellow.career_steps.first.update completed: true
+      fellow.completed_career_steps = completed_positions 
+    end
+    
+    subject { fellow.completed_career_steps }
+    
+    it { should eq(completed_positions) }
+  end
 end

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Fellow, type: :model do
   it { should have_many :cohort_fellows }
   it { should have_many :cohorts }
   it { should have_many :fellow_opportunities }
+  it { should have_many :career_steps }
   
   it { should have_and_belong_to_many :interests }
   it { should have_and_belong_to_many :industries }
@@ -347,5 +348,17 @@ RSpec.describe Fellow, type: :model do
       expect(PostalCode).to receive(:find_by).with(code: fellow.contact.postal_code).once.and_return(postal_code)
       2.times { fellow.default_metro }
     end
+  end
+  
+  describe '#generate_career_steps' do
+    subject { fellow.career_steps }
+    
+    it { expect(subject[0].position).to eq(0) }
+    it { expect(subject[0].name).to eq('strengths') }
+    it { expect(subject[0].description).to eq('I know my strengths and values and can communicate my story') }
+    
+    it { expect(subject[11].position).to eq(11) }
+    it { expect(subject[11].name).to eq('employers') }
+    it { expect(subject[11].description).to eq("I've made a shortlist of positions and/or employers") }
   end
 end

--- a/spec/routing/fellow/home_routing_spec.rb
+++ b/spec/routing/fellow/home_routing_spec.rb
@@ -1,0 +1,13 @@
+require_relative "../../rails_helper"
+
+RSpec.describe Fellow::HomeController, type: :routing do
+  describe "routing" do
+    it "routes to #welcome via GET" do
+      expect(:get => "fellow/home/welcome").to route_to("fellow/home#welcome")
+    end
+
+    it "routes to #career via POST" do
+      expect(post: '/fellow/home/career').to route_to('fellow/home#career')
+    end
+  end
+end


### PR DESCRIPTION
The screencap is going to look really simple. If you're looking at your career tracker tiles, you click them, and the steps you've completed get updated behind the scenes. In the screencap, the page reloads on every click, but the latest commit gets rid of this so fellows don't lose their place on the page.

In the background, career steps are saved and tracked in a flexible way, so that we can change steps down the line without affecting the career paths of previous fellows. In fact, different fellows could have different sets of career paths. A fellow is assigned their own copy of our standardized career paths at creation time, but can be altered later as needed.

screencap: http://bit.ly/2KZZL3E

![screen shot 2018-08-16 at 3 33 46 pm](https://user-images.githubusercontent.com/12893/44233557-cabfb700-a169-11e8-942c-636ecb429fe7.png)
