### PR TITLE
Fix candidate search errors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,4 +33,9 @@ module ApplicationHelper
 
     [sorted_list[0...half], sorted_list[half..-1]]
   end
+  
+  def nearest_distance fellow, postal_codes
+    distance = fellow.nearest_distance(postal_codes)
+    distance ? pluralize(distance.round, 'mile') : 'N/A'
+  end
 end

--- a/app/views/admin/candidates/index.html.erb
+++ b/app/views/admin/candidates/index.html.erb
@@ -67,7 +67,7 @@
               <% end %>
             </ul>
           </td>
-          <td><%= pluralize(fellow.nearest_distance(@opportunity.postal_codes).round, 'mile') %>
+          <td><%= nearest_distance(fellow, @opportunity.postal_codes) %>
           <td><%= fellow.employment_status.name %></td>
         </tr>
       <% end %>

--- a/app/views/admin/fellows/_form.html.erb
+++ b/app/views/admin/fellows/_form.html.erb
@@ -37,11 +37,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :interests_description %>
-    <%= form.text_area :interests_description %>
-  </div>
-
-  <div class="field">
     <%= form.label :major %>
     <%= form.text_field :major %>
   </div>

--- a/app/views/admin/fellows/show.html.erb
+++ b/app/views/admin/fellows/show.html.erb
@@ -27,10 +27,6 @@
       <th>Graduation fiscal year:</th>
       <td><%= @fellow.graduation_fiscal_year %></td>
     </tr>
-    <tr class="new-section">
-      <th>Interests description:</th>
-      <td><%= @fellow.interests_description %></td>
-    </tr>
     <tr>
       <th>Major:</th>
       <td><%= @fellow.major %></td>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -76,4 +76,35 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(split[1]).to eq([:d, :e])
     end
   end
+  
+  describe '#nearest_distance(fellow, postal_codes)' do
+    let(:postal_codes) { ['12345', '23456'] }
+    let(:fellow) { build :fellow }
+    
+    before do
+      allow(fellow).to receive(:nearest_distance).with(postal_codes).and_return(distance)
+    end
+    
+    subject { nearest_distance(fellow, postal_codes) }
+
+    describe 'when a nearest distance is zero' do
+      let(:distance) { 0 }
+      it { should eq("0 miles") }
+    end
+    
+    describe 'when a nearest distance is singular' do
+      let(:distance) { 1 }
+      it { should eq("1 mile") }
+    end
+    
+    describe 'when a nearest distance is plural' do
+      let(:distance) { 2 }
+      it { should eq("2 miles") }
+    end
+    
+    describe 'when no nearest distance is returned' do
+      let(:distance) { nil }
+      it { should eq("N/A") }
+    end
+  end
 end


### PR DESCRIPTION
This addresses the candidate search errors we've experienced:

* If we don't have location data for a fellow, return "N/A" for the "distance" during a candidate search. This is better than just breaking the app.
* Don't show the "interests description" field in fellow forms or views. This was causing confusion, because staff thought if they added an interest there, "free form" style, it would apply to candidate searches. It does not. Searches only use the interest/industry/major and location tags, not free-form text fields. So there's no point in showing or maintaining that field at all. It's gone now. Shhhh....It can't hurt you anymore.

![20180820-specs](https://user-images.githubusercontent.com/12893/44357376-783b0f00-a477-11e8-9283-a2ec07b595ca.png)
