### PR TITLE
More candidate search fixes

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -27,7 +27,7 @@ class Cohort < ApplicationRecord
           })
         end
 
-        fellow.metros << fellow.default_metro if fellow.default_metro
+        fellow.add_metro(fellow.default_metro)
 
         proxy_association.owner.cohort_fellows.find_or_create_by(fellow_id: fellow.id).update(cohort_fellow_attributes)
       rescue ActiveRecord::RecordInvalid

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -111,7 +111,7 @@ class Fellow < ApplicationRecord
   end
   
   def nearest_distance zip_list
-    zip_list.map{|zip| distance_from(zip)}.min
+    zip_list.map{|zip| distance_from(zip)}.compact.min
   end
   
   def distance_from postal_code

--- a/app/models/postal_code.rb
+++ b/app/models/postal_code.rb
@@ -10,7 +10,10 @@ class PostalCode < ApplicationRecord
   class << self
     def distance origin_zip, destination_zip
       origin = find_by code: origin_zip
+      return nil if origin.nil?
+      
       destination = find_by code: destination_zip
+      return nil if destination.nil?
       
       GeoDistance.haversine(origin.coordinates, destination.coordinates)
     end

--- a/lib/taggable.rb
+++ b/lib/taggable.rb
@@ -81,5 +81,11 @@ module Taggable
     def metro_tags= tag_string
       self.metro_ids = Metro.where(name: tag_string.split(';')).pluck(:id)
     end
+    
+    def add_metro metro
+      if (metro && !self.metros.include?(metro))
+        self.metros << metro
+      end
+    end
   end
 end


### PR DESCRIPTION
A couple more fixes:

* multiple imports are supposed to avoid recreating existing fellows, and they do, but they weren't preventing adding the default metro area to the fellow over and over again. This has been fixed.
* if, for some reason, we don't have coordinates for a given zip code, or if a zip code is missing for an opp or fellow, we now skip trying to calculate the distance between the candidate and opp. This will prevent an error page when valid coordinates are compared with "nil".

![20180821-specs](https://user-images.githubusercontent.com/12893/44421426-14cbe280-a546-11e8-8d05-8a7db0fadf4b.png)
