### PR TITLE
Opportunity Intake for Newsletter

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -425,3 +425,7 @@ ul.inline-list {
   padding-right: 20px;
   margin: 0
 }
+
+label.checkbox {
+  display: inline;
+}

--- a/app/controllers/admin/employers_controller.rb
+++ b/app/controllers/admin/employers_controller.rb
@@ -76,6 +76,6 @@ class Admin::EmployersController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def employer_params
-      params.require(:employer).permit(:name, :industry_tags, industry_ids: [])
+      params.require(:employer).permit(:name, :employer_partner, :industry_tags, industry_ids: [])
     end
 end

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -7,13 +7,15 @@ class Admin::OpportunitiesController < ApplicationController
   # GET /opportunities
   # GET /opportunities.json
   def index
+  end
+  
+  def export
     respond_to do |format|
-      format.html
-      format.json
-      
       format.csv do
         @opportunities = unpaginated_opportunities
-        
+        Rails.logger.info("OPPS: #{@opportunities.inspect}")
+        Opportunity.where(id: @opportunities.map(&:id)).update_all(published: true)
+    
         headers['Content-Disposition'] = "attachment; filename=\"opportunities.csv\""
         headers['Content-Type'] ||= 'text/csv'
       end
@@ -86,7 +88,7 @@ class Admin::OpportunitiesController < ApplicationController
   end
   
   def unpaginated_opportunities
-    (@employer ? @employer.opportunities : Opportunity.all).sort_by(&:priority).sort_by{|o| o.region.position}
+    (@employer ? @employer.opportunities : Opportunity).where(id: params[:export_ids]).sort_by(&:priority).sort_by{|o| o.region.position}
   end
   
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -12,6 +12,8 @@ class Admin::OpportunitiesController < ApplicationController
       format.json
       
       format.csv do
+        @opportunities = unpaginated_opportunities
+        
         headers['Content-Disposition'] = "attachment; filename=\"opportunities.csv\""
         headers['Content-Type'] ||= 'text/csv'
       end
@@ -81,6 +83,10 @@ class Admin::OpportunitiesController < ApplicationController
   def set_employer
     @employer = Employer.find(params[:employer_id]) if params[:employer_id]
     @opportunities = (@employer ? @employer.opportunities : Opportunity).paginate(page: params[:page])
+  end
+  
+  def unpaginated_opportunities
+    (@employer ? @employer.opportunities : Opportunity.all).sort_by(&:priority).sort_by{|o| o.region.position}
   end
   
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -83,7 +83,8 @@ class Admin::OpportunitiesController < ApplicationController
   def opportunity_params
     params.require(:opportunity).permit(
       :_destroy,
-      :name, :description, :employer_id, :job_posting_url, :application_deadline, :inbound, :recurring, :opportunity_type_id,
+      :name, :description, :employer_id, :job_posting_url, :application_deadline, 
+      :inbound, :recurring, :opportunity_type_id, :region_id,
       :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
       industry_ids: [], 
       interest_ids: [],

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -7,6 +7,15 @@ class Admin::OpportunitiesController < ApplicationController
   # GET /opportunities
   # GET /opportunities.json
   def index
+    respond_to do |format|
+      format.html
+      format.json
+      
+      format.csv do
+        headers['Content-Disposition'] = "attachment; filename=\"opportunities.csv\""
+        headers['Content-Type'] ||= 'text/csv'
+      end
+    end
   end
 
   # GET /opportunities/1

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -83,7 +83,7 @@ class Admin::OpportunitiesController < ApplicationController
   def opportunity_params
     params.require(:opportunity).permit(
       :_destroy,
-      :name, :description, :employer_id, :job_posting_url, :application_deadline,
+      :name, :description, :employer_id, :job_posting_url, :application_deadline, :inbound, :recurring,
       :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
       industry_ids: [], 
       interest_ids: [],

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -83,7 +83,7 @@ class Admin::OpportunitiesController < ApplicationController
   def opportunity_params
     params.require(:opportunity).permit(
       :_destroy,
-      :name, :description, :employer_id, :job_posting_url, :application_deadline, :inbound, :recurring,
+      :name, :description, :employer_id, :job_posting_url, :application_deadline, :inbound, :recurring, :opportunity_type_id,
       :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
       industry_ids: [], 
       interest_ids: [],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class ApplicationController < ActionController::Base
   before_action :set_requested_redirect
   

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -161,15 +161,17 @@ class Opportunity < ApplicationRecord
         (recurring ? 'yes' : 'no'),
         (interests + industries + majors).map(&:name).uniq.sort.join(', ')
       ]
-    rescue => e
-      Rails.logger.info("COULD NOT EXPORT OPP #{id}: #{e.message}")
-      nil
+    # rescue => e
+    #   Rails.logger.info("COULD NOT EXPORT OPP #{id}: #{e.message}")
+    #   nil
     end
   end
   
   def primary_city_state
     if metros.first
-      city, state = metros.first.name.split(/,\s+/)
+      metro_name = metros.first.name
+      
+      city, state = metro_name.split(/,\s+/)
     
       return metro_name unless state
       primary_state, secondary_state = state.split('-', 2)

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -21,12 +21,12 @@ class Opportunity < ApplicationRecord
   serialize :steps, Array
   
   validates :name, presence: true
-  validates :job_posting_url, url: {ensure_protocol: true}, allow_blank: true
+  validates :job_posting_url, url: {ensure_protocol: true}
   validate :validate_locateable
   
   class << self
     def csv_headers
-      ['Region', 'Employer', 'Position', 'Type', 'City', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
+      ['Region', 'Employer', 'Position', 'Type', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
     end
   end
   

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -5,6 +5,7 @@ class Opportunity < ApplicationRecord
   
   belongs_to :employer
   belongs_to :opportunity_type
+  belongs_to :region
   
   has_many :tasks, as: :taskable, dependent: :destroy
   accepts_nested_attributes_for :tasks, reject_if: :all_blank, allow_destroy: true

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -154,7 +154,7 @@ class Opportunity < ApplicationRecord
         employer.name,
         "=HYPERLINK(\"#{job_posting_url}\", \"#{name}\")",
         opportunity_type.name,
-        locations.first.contact.city,
+        primary_city_state(metros.first.name),
         job_posting_url,
         (employer.employer_partner ? 'yes' : 'no'),
         (inbound ? 'yes' : 'no'),
@@ -164,6 +164,15 @@ class Opportunity < ApplicationRecord
     rescue
       nil
     end
+  end
+  
+  def primary_city_state metro_name
+    city, state = metro_name.split(/,\s+/)
+    
+    return metro_name unless state
+    primary_state, secondary_state = state.split('-', 2)
+    
+    [city, primary_state].join(', ')
   end
   
   # lowest priority is best/first

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -152,7 +152,7 @@ class Opportunity < ApplicationRecord
       [
         region.name,
         employer.name,
-        name,
+        "=HYPERLINK(\"#{job_posting_url}\", \"#{name}\")",
         opportunity_type.name,
         locations.first.contact.city,
         job_posting_url,

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -168,16 +168,22 @@ class Opportunity < ApplicationRecord
   
   # lowest priority is best/first
   def priority
-    if employer.employer_partner && inbound && recurring
+    employer_partner = employer.employer_partner
+    
+    if employer_partner && inbound && recurring
       0
-    elsif employer.employer_partner && inbound
+    elsif employer_partner && inbound
       1
-    elsif employer.employer_partner || inbound
+    elsif inbound
       2
-    elsif recurring
+    elsif employer_partner && recurring
       3
-    else
+    elsif employer_partner
       4
+    elsif recurring
+      5
+    else
+      6
     end
   end
   

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -24,6 +24,12 @@ class Opportunity < ApplicationRecord
   validates :job_posting_url, url: {ensure_protocol: true}, allow_blank: true
   validate :validate_locateable
   
+  class << self
+    def csv_headers
+      ['Region', 'Employer', 'Position', 'Type', 'City', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
+    end
+  end
+  
   def candidates search_params=nil
     search_params ||= {}
     return @candidates if defined?(@candidates)
@@ -139,6 +145,25 @@ class Opportunity < ApplicationRecord
   
   def postal_codes
     locations.map(&:contact).compact.map(&:postal_code).compact
+  end
+  
+  def csv_fields
+    begin
+      [
+        region.name,
+        employer.name,
+        name,
+        opportunity_type.name,
+        locations.first.contact.city,
+        job_posting_url,
+        (employer.employer_partner ? 'yes' : 'no'),
+        (inbound ? 'yes' : 'no'),
+        (recurring ? 'yes' : 'no'),
+        (interests + industries + majors).map(&:name).uniq.sort.join(', ')
+      ]
+    rescue
+      nil
+    end
   end
   
   private

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -4,6 +4,7 @@ class Opportunity < ApplicationRecord
   include Taggable
   
   belongs_to :employer
+  belongs_to :opportunity_type
   
   has_many :tasks, as: :taskable, dependent: :destroy
   accepts_nested_attributes_for :tasks, reject_if: :all_blank, allow_destroy: true

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -166,6 +166,21 @@ class Opportunity < ApplicationRecord
     end
   end
   
+  # lowest priority is best/first
+  def priority
+    if employer.employer_partner && inbound && recurring
+      0
+    elsif employer.employer_partner && inbound
+      1
+    elsif employer.employer_partner || inbound
+      2
+    elsif recurring
+      3
+    else
+      4
+    end
+  end
+  
   private
   
   def archived_fellow_opp candidate_id

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -154,25 +154,32 @@ class Opportunity < ApplicationRecord
         employer.name,
         "=HYPERLINK(\"#{job_posting_url}\", \"#{name}\")",
         opportunity_type.name,
-        primary_city_state(metros.first.name),
+        primary_city_state,
         job_posting_url,
         (employer.employer_partner ? 'yes' : 'no'),
         (inbound ? 'yes' : 'no'),
         (recurring ? 'yes' : 'no'),
         (interests + industries + majors).map(&:name).uniq.sort.join(', ')
       ]
-    rescue
+    rescue => e
+      Rails.logger.info("COULD NOT EXPORT OPP #{id}: #{e.message}")
       nil
     end
   end
   
-  def primary_city_state metro_name
-    city, state = metro_name.split(/,\s+/)
+  def primary_city_state
+    if metros.first
+      city, state = metros.first.name.split(/,\s+/)
     
-    return metro_name unless state
-    primary_state, secondary_state = state.split('-', 2)
+      return metro_name unless state
+      primary_state, secondary_state = state.split('-', 2)
     
-    [city, primary_state].join(', ')
+      [city, primary_state].join(', ')
+    else
+      contact = locations.first.contact
+      
+      [contact.city, contact.state].join(', ')
+    end
   end
   
   # lowest priority is best/first

--- a/app/models/opportunity_type.rb
+++ b/app/models/opportunity_type.rb
@@ -2,4 +2,11 @@ class OpportunityType < ApplicationRecord
   has_many :opportunities
   
   validates :name, :position, presence: true, uniqueness: true
+  
+  class << self
+    def types
+      return @types if defined?(@types)
+      @types = YAML.load(File.read("#{Rails.root}/config/opportunity_types.yml"))
+    end
+  end
 end

--- a/app/models/opportunity_type.rb
+++ b/app/models/opportunity_type.rb
@@ -1,0 +1,5 @@
+class OpportunityType < ApplicationRecord
+  has_many :opportunities
+  
+  validates :name, :position, presence: true, uniqueness: true
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,0 +1,5 @@
+class Region < ApplicationRecord
+  has_many :opportunities
+  
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,5 +1,12 @@
 class Region < ApplicationRecord
   has_many :opportunities
   
-  validates :name, presence: true, uniqueness: true
+  validates :name, :position, presence: true, uniqueness: true
+  
+  class << self
+    def types
+      return @types if defined?(@types)
+      @types = YAML.load(File.read("#{Rails.root}/config/regions.yml"))
+    end
+  end
 end

--- a/app/views/admin/employers/_form.html.erb
+++ b/app/views/admin/employers/_form.html.erb
@@ -15,6 +15,11 @@
     <%= form.label :name %>
     <%= form.text_field :name, required: true %>
   </div>
+
+  <div class="field">
+    <%= form.check_box :employer_partner %>
+    <%= form.label :employer_partner, 'Employer Partner?', class: 'checkbox' %>
+  </div>
   
   <h3>Industries</h3>
 

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :opportunity_type_id, 'Opportunity Type' %>
+    <%= form.collection_select(:opportunity_type_id, OpportunityType.order(position: :asc), :id, :name) %>
+  </div>
+
+  <div class="field">
     <%= form.check_box :inbound %>
     <%= form.label :inbound, 'Inbound?', class: 'checkbox' %>
   </div>

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -43,7 +43,7 @@
 
   <div class="field">
     <%= form.label :job_posting_url %>
-    <%= form.text_field :job_posting_url %>
+    <%= form.text_field :job_posting_url, required: true %>
   </div>
   
   <div class="field">

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -22,6 +22,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :region_id, 'Region' %>
+    <%= form.collection_select(:region_id, Region.order(name: :asc), :id, :name) %>
+  </div>
+
+  <div class="field">
     <%= form.check_box :inbound %>
     <%= form.label :inbound, 'Inbound?', class: 'checkbox' %>
   </div>

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -17,6 +17,16 @@
   </div>
 
   <div class="field">
+    <%= form.check_box :inbound %>
+    <%= form.label :inbound, 'Inbound?', class: 'checkbox' %>
+  </div>
+
+  <div class="field">
+    <%= form.check_box :recurring %>
+    <%= form.label :recurring, 'Recurring?', class: 'checkbox' %>
+  </div>
+
+  <div class="field">
     <%= form.label :description, 'Description (please keep it short!)' %>
     <%= form.text_area :description %>
   </div>

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -23,7 +23,7 @@
 
   <div class="field">
     <%= form.label :region_id, 'Region' %>
-    <%= form.collection_select(:region_id, Region.order(name: :asc), :id, :name) %>
+    <%= form.collection_select(:region_id, Region.order(position: :asc), :id, :name) %>
   </div>
 
   <div class="field">

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -1,26 +1,32 @@
 <% if opportunities.empty? %>
   <p class="empty-list">There are no opportunities for this employer yet.</p>
 <% else %>
-  <table>
-    <thead>
-      <tr>
-        <th>Employer</th>
-        <th>Title</th>
-        <th>Description</th>
-        <th colspan="2">Actions</th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% opportunities.each do |opportunity| %>
+  <%= form_tag export_admin_opportunities_path(format: 'csv'), method: :post do %>
+    <table>
+      <thead>
         <tr>
-          <td><%= opportunity.employer.name %>
-          <td><%= link_to opportunity.name, admin_opportunity_path(opportunity) %></td>
-          <td><%= truncate(opportunity.description, length: 100, separator: ' ') %></td>
-          <td><%= link_to 'Edit', edit_admin_opportunity_path(opportunity), class: 'edit' %></td>
-          <td><%= link_to 'Delete', admin_opportunity_path(opportunity), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %></td>
+          <th>Employer</th>
+          <th>Title</th>
+          <th>Description</th>
+          <th colspan="2">Actions</th>
+          <th>Export</th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+
+      <tbody>
+        <% opportunities.each do |opportunity| %>
+          <tr>
+            <td><%= opportunity.employer.name %>
+            <td><%= link_to opportunity.name, admin_opportunity_path(opportunity) %></td>
+            <td><%= truncate(opportunity.description, length: 100, separator: ' ') %></td>
+            <td><%= link_to 'Edit', edit_admin_opportunity_path(opportunity), class: 'edit' %></td>
+            <td><%= link_to 'Delete', admin_opportunity_path(opportunity), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %></td>
+            <td><%= check_box_tag 'export_ids[]', opportunity.id, !opportunity.published %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <p><%= submit_tag 'Export to CSV' %></p>
+  <% end %>
 <% end %>

--- a/app/views/admin/opportunities/export.csv.erb
+++ b/app/views/admin/opportunities/export.csv.erb
@@ -1,5 +1,5 @@
-<%= CSV.generate_line Opportunity.csv_headers %>
+<%= CSV.generate_line Opportunity.csv_headers -%>
 <%- @opportunities.each do |opp| -%>
-<%- next unless opp.csv_fields %>
+<%- next unless opp.csv_fields -%>
 <%= CSV.generate_line(opp.csv_fields).html_safe -%>
 <%- end -%>

--- a/app/views/admin/opportunities/index.csv.erb
+++ b/app/views/admin/opportunities/index.csv.erb
@@ -1,0 +1,5 @@
+<%= CSV.generate_line Opportunity.csv_headers %>
+<%- @opportunities.each do |opp| -%>
+<%- next unless opp.csv_fields %>
+<%= CSV.generate_line(opp.csv_fields).html_safe -%>
+<%- end -%>

--- a/app/views/admin/opportunities/index.html.erb
+++ b/app/views/admin/opportunities/index.html.erb
@@ -1,11 +1,7 @@
 <h1><%= @employer ? "#{@employer.name} " : '' %>Opportunities</h1>
 
-<p><%= link_to 'Export to CSV', admin_opportunities_path(format: 'csv'), class: "button" %></p>
+<p><%= link_to 'Add New Opportunity', (@employer ? new_admin_employer_opportunity_path(@employer) : admin_new_opportunity_path), class: 'button add' %></p>
 
 <%= render "admin/opportunities/list", opportunities: @opportunities %>
 
 <%= will_paginate @opportunities %>
-
-<br>
-
-<%= link_to 'Add New Opportunity', (@employer ? new_admin_employer_opportunity_path(@employer) : admin_new_opportunity_path), class: 'button add' %>

--- a/app/views/admin/opportunities/index.html.erb
+++ b/app/views/admin/opportunities/index.html.erb
@@ -1,5 +1,7 @@
 <h1><%= @employer ? "#{@employer.name} " : '' %>Opportunities</h1>
 
+<p><%= link_to 'Export to CSV', admin_opportunities_path(format: 'csv'), class: "button" %></p>
+
 <%= render "admin/opportunities/list", opportunities: @opportunities %>
 
 <%= will_paginate @opportunities %>

--- a/config/opportunity_types.yml
+++ b/config/opportunity_types.yml
@@ -1,0 +1,9 @@
+- Internship
+- Job
+- Work Study
+- Externship
+- Co-op
+- Event
+- Micro-Internship
+- Fellowship
+- Volunteer

--- a/config/regions.yml
+++ b/config/regions.yml
@@ -1,0 +1,4 @@
+- Chicago, IL
+- Newark, NJ
+- San Jose, CA
+- Nationwide

--- a/config/regions.yml
+++ b/config/regions.yml
@@ -1,4 +1,4 @@
-- Chicago, IL
-- Newark, NJ
-- San Jose, CA
+- Bay
+- Newark
+- Chicago
 - Nationwide

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,11 @@ Rails.application.routes.draw do
       end
     end
   
-    resources :opportunities, only: [:index]
+    resources :opportunities, only: [:index] do
+      collection do
+        post :export
+      end
+    end
 
     resources :sites, shallow: true do
       resources :courses, except: [:index]

--- a/db/migrate/20180827142646_add_employer_partner_to_employers.rb
+++ b/db/migrate/20180827142646_add_employer_partner_to_employers.rb
@@ -1,0 +1,6 @@
+class AddEmployerPartnerToEmployers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :employers, :employer_partner, :boolean, default: false
+    add_index :employers, :employer_partner
+  end
+end

--- a/db/migrate/20180827144720_add_booleans_to_opportunities.rb
+++ b/db/migrate/20180827144720_add_booleans_to_opportunities.rb
@@ -1,0 +1,9 @@
+class AddBooleansToOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :inbound, :boolean, default: false
+    add_index :opportunities, :inbound
+    
+    add_column :opportunities, :recurring, :boolean, default: false
+    add_index :opportunities, :recurring
+  end
+end

--- a/db/migrate/20180827152416_create_opportunity_types.rb
+++ b/db/migrate/20180827152416_create_opportunity_types.rb
@@ -1,0 +1,12 @@
+class CreateOpportunityTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :opportunity_types do |t|
+      t.string :name
+      t.integer :position
+
+      t.timestamps
+    end
+    add_index :opportunity_types, :name
+    add_index :opportunity_types, :position
+  end
+end

--- a/db/migrate/20180827153400_add_opportunity_type_id_to_opportunities.rb
+++ b/db/migrate/20180827153400_add_opportunity_type_id_to_opportunities.rb
@@ -1,0 +1,6 @@
+class AddOpportunityTypeIdToOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :opportunity_type_id, :integer
+    add_index :opportunities, :opportunity_type_id
+  end
+end

--- a/db/migrate/20180827185132_load_opportunity_types.rb
+++ b/db/migrate/20180827185132_load_opportunity_types.rb
@@ -1,0 +1,20 @@
+class LoadOpportunityTypes < ActiveRecord::Migration[5.2]
+  def up
+    OpportunityType.destroy_all
+
+    OpportunityType.types.each_with_index do |name, position|
+      OpportunityType.create name: name, position: position
+      print '.'; $stdout.flush
+    end
+    
+    puts
+    
+    job = OpportunityType.find_by name: 'Job'
+    Opportunity.update_all(opportunity_type_id: job.id)
+  end
+  
+  def down
+    OpportunityType.destroy_all
+    Opportunity.update_all(opportunity_type_id: nil)
+  end
+end

--- a/db/migrate/20180827202300_create_regions.rb
+++ b/db/migrate/20180827202300_create_regions.rb
@@ -1,0 +1,10 @@
+class CreateRegions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :regions do |t|
+      t.string :name
+
+      t.timestamps
+    end
+    add_index :regions, :name
+  end
+end

--- a/db/migrate/20180827202757_add_region_id_to_opportununities.rb
+++ b/db/migrate/20180827202757_add_region_id_to_opportununities.rb
@@ -1,0 +1,6 @@
+class AddRegionIdToOpportununities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :region_id, :integer
+    add_index :opportunities, :region_id
+  end
+end

--- a/db/migrate/20180827204909_add_position_to_regions.rb
+++ b/db/migrate/20180827204909_add_position_to_regions.rb
@@ -1,0 +1,6 @@
+class AddPositionToRegions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :regions, :position, :integer
+    add_index :regions, :position
+  end
+end

--- a/db/migrate/20180827213509_load_regions.rb
+++ b/db/migrate/20180827213509_load_regions.rb
@@ -1,0 +1,20 @@
+class LoadRegions < ActiveRecord::Migration[5.2]
+  def up
+    Region.destroy_all
+
+    Region.types.each_with_index do |name, position|
+      Region.create name: name, position: position
+      print '.'; $stdout.flush
+    end
+    
+    puts
+    
+    nationwide = Region.find_by name: 'Nationwide'
+    Opportunity.update_all(region_id: nationwide.id)
+  end
+  
+  def down
+    Region.destroy_all
+    Opportunity.update_all(region_id: nil)
+  end
+end

--- a/db/migrate/20180829145401_add_published_boolean_to_opportunities.rb
+++ b/db/migrate/20180829145401_add_published_boolean_to_opportunities.rb
@@ -1,0 +1,6 @@
+class AddPublishedBooleanToOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :published, :boolean, default: false
+    add_index :opportunities, :published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_08_193539) do
+ActiveRecord::Schema.define(version: 2018_08_27_142646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,8 @@ ActiveRecord::Schema.define(version: 2018_08_08_193539) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "employer_partner", default: false
+    t.index ["employer_partner"], name: "index_employers_on_employer_partner"
     t.index ["name"], name: "index_employers_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_153400) do
+ActiveRecord::Schema.define(version: 2018_08_27_185132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_213509) do
+ActiveRecord::Schema.define(version: 2018_08_29_145401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -294,6 +294,14 @@ ActiveRecord::Schema.define(version: 2018_08_27_213509) do
     t.index ["opportunity_id", "major_id"], name: "index_majors_opportunities_on_opportunity_id_and_major_id"
   end
 
+  create_table "metro_relationships", id: false, force: :cascade do |t|
+    t.integer "parent_id"
+    t.integer "child_id"
+    t.index ["child_id"], name: "index_metro_relationships_on_child_id"
+    t.index ["parent_id", "child_id"], name: "index_metro_relationships_on_parent_id_and_child_id"
+    t.index ["parent_id"], name: "index_metro_relationships_on_parent_id"
+  end
+
   create_table "metros", force: :cascade do |t|
     t.string "code"
     t.string "name"
@@ -327,9 +335,11 @@ ActiveRecord::Schema.define(version: 2018_08_27_213509) do
     t.boolean "recurring", default: false
     t.integer "opportunity_type_id"
     t.integer "region_id"
+    t.boolean "published", default: false
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"
+    t.index ["published"], name: "index_opportunities_on_published"
     t.index ["recurring"], name: "index_opportunities_on_recurring"
     t.index ["region_id"], name: "index_opportunities_on_region_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_144720) do
+ActiveRecord::Schema.define(version: 2018_08_27_153400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -325,8 +325,10 @@ ActiveRecord::Schema.define(version: 2018_08_27_144720) do
     t.text "steps"
     t.boolean "inbound", default: false
     t.boolean "recurring", default: false
+    t.integer "opportunity_type_id"
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
+    t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"
     t.index ["recurring"], name: "index_opportunities_on_recurring"
   end
 
@@ -341,6 +343,15 @@ ActiveRecord::Schema.define(version: 2018_08_27_144720) do
     t.boolean "active_status", default: true
     t.index ["name"], name: "index_opportunity_stages_on_name", unique: true
     t.index ["togglable"], name: "index_opportunity_stages_on_togglable"
+  end
+
+  create_table "opportunity_types", force: :cascade do |t|
+    t.string "name"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_opportunity_types_on_name"
+    t.index ["position"], name: "index_opportunity_types_on_position"
   end
 
   create_table "postal_codes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_202757) do
+ActiveRecord::Schema.define(version: 2018_08_27_204909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -370,7 +370,9 @@ ActiveRecord::Schema.define(version: 2018_08_27_202757) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position"
     t.index ["name"], name: "index_regions_on_name"
+    t.index ["position"], name: "index_regions_on_position"
   end
 
   create_table "sites", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_142646) do
+ActiveRecord::Schema.define(version: 2018_08_27_144720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -323,7 +323,11 @@ ActiveRecord::Schema.define(version: 2018_08_27_142646) do
     t.string "job_posting_url"
     t.date "application_deadline"
     t.text "steps"
+    t.boolean "inbound", default: false
+    t.boolean "recurring", default: false
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
+    t.index ["inbound"], name: "index_opportunities_on_inbound"
+    t.index ["recurring"], name: "index_opportunities_on_recurring"
   end
 
   create_table "opportunity_stages", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_185132) do
+ActiveRecord::Schema.define(version: 2018_08_27_202757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -326,10 +326,12 @@ ActiveRecord::Schema.define(version: 2018_08_27_185132) do
     t.boolean "inbound", default: false
     t.boolean "recurring", default: false
     t.integer "opportunity_type_id"
+    t.integer "region_id"
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"
     t.index ["recurring"], name: "index_opportunities_on_recurring"
+    t.index ["region_id"], name: "index_opportunities_on_region_id"
   end
 
   create_table "opportunity_stages", force: :cascade do |t|
@@ -362,6 +364,13 @@ ActiveRecord::Schema.define(version: 2018_08_27_185132) do
     t.datetime "updated_at", null: false
     t.string "msa_code"
     t.index ["code"], name: "index_postal_codes_on_code"
+  end
+
+  create_table "regions", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_regions_on_name"
   end
 
   create_table "sites", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_204909) do
+ActiveRecord::Schema.define(version: 2018_08_27_213509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/admin/employers_controller_spec.rb
+++ b/spec/controllers/admin/employers_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Admin::EmployersController, type: :controller do
   # This should return the minimal set of attributes required to create a valid
   # Employer. As you add validations to Employer, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) { attributes_for :employer }
+  let(:valid_attributes) { attributes_for(:employer).merge(employer_partner: true) }
   let(:invalid_attributes) { {name: ''} }
   
   let(:industry) { create :industry }
@@ -140,6 +140,13 @@ RSpec.describe Admin::EmployersController, type: :controller do
       it "associates specified industries with the employer" do
         post :create, params: {employer: valid_attributes.merge(industry_ids: [industry.id.to_s])}, session: valid_session
         expect(Employer.last.industries).to include(industry)
+      end
+      
+      it "sets employer partner status" do
+        post :create, params: {employer: valid_attributes}, session: valid_session
+        employer = Employer.last
+        
+        expect(employer.employer_partner).to eq(true)
       end
     end
 

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
   # Opportunity. As you add validations to Opportunity, be sure to
   # adjust the attributes here as well.
   let(:employer) { create :employer }
+  let(:opportunity_type) { create :opportunity_type }
   
   let(:industry) { create :industry }
   let(:interest) { create :interest }
@@ -39,7 +40,7 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
   let(:contact)  { create :contact}
   let(:location) { create :location, contact: contact, locateable: saved_employer }
 
-  let(:valid_attributes) { attributes_for :opportunity, employer_id: employer.id, inbound: true, recurring: true, locations_attributes: {"0" => {locateable_type: 'Employer', locateable_id: employer.id, contact_attributes: {postal_code: '12345'}}} }
+  let(:valid_attributes) { attributes_for :opportunity, employer_id: employer.id, inbound: true, recurring: true, opportunity_type_id: opportunity_type.id, locations_attributes: {"0" => {locateable_type: 'Employer', locateable_id: employer.id, contact_attributes: {postal_code: '12345'}}} }
   let(:invalid_attributes) { { name: ''} }
   
   # This should return the minimal set of values that should be in the session

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
   let(:contact)  { create :contact}
   let(:location) { create :location, contact: contact, locateable: saved_employer }
 
-  let(:valid_attributes) { attributes_for :opportunity, employer_id: employer.id, locations_attributes: {"0" => {locateable_type: 'Employer', locateable_id: employer.id, contact_attributes: {postal_code: '12345'}}} }
+  let(:valid_attributes) { attributes_for :opportunity, employer_id: employer.id, inbound: true, recurring: true, locations_attributes: {"0" => {locateable_type: 'Employer', locateable_id: employer.id, contact_attributes: {postal_code: '12345'}}} }
   let(:invalid_attributes) { { name: ''} }
   
   # This should return the minimal set of values that should be in the session
@@ -222,6 +222,14 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
         it "associates specified interests with the opportunity" do
           post :create, params: {employer_id: employer.id, opportunity: valid_attributes.merge(interest_ids: [interest.id.to_s])}, session: valid_session
           expect(Opportunity.last.interests).to include(interest)
+        end
+        
+        it "sets the inbound/recurring booleans" do
+          post :create, params: {employer_id: employer.id, opportunity: valid_attributes}, session: valid_session
+          opportunity = Opportunity.last
+          
+          expect(opportunity.inbound).to eq(true)
+          expect(opportunity.recurring).to eq(true)
         end
       end
 

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
   # adjust the attributes here as well.
   let(:employer) { create :employer }
   let(:opportunity_type) { create :opportunity_type }
+  let(:region) { create :region }
   
   let(:industry) { create :industry }
   let(:interest) { create :interest }
@@ -40,7 +41,7 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
   let(:contact)  { create :contact}
   let(:location) { create :location, contact: contact, locateable: saved_employer }
 
-  let(:valid_attributes) { attributes_for :opportunity, employer_id: employer.id, inbound: true, recurring: true, opportunity_type_id: opportunity_type.id, locations_attributes: {"0" => {locateable_type: 'Employer', locateable_id: employer.id, contact_attributes: {postal_code: '12345'}}} }
+  let(:valid_attributes) { attributes_for :opportunity, employer_id: employer.id, inbound: true, recurring: true, opportunity_type_id: opportunity_type.id, region_id: region.id, locations_attributes: {"0" => {locateable_type: 'Employer', locateable_id: employer.id, contact_attributes: {postal_code: '12345'}}} }
   let(:invalid_attributes) { { name: ''} }
   
   # This should return the minimal set of values that should be in the session

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
       expect(response).to be_successful
     end
   end
+  
+  describe 'POST #export' do
+    it "returns a success response" do
+      post :export, params: {format: 'csv'}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
 
   describe "GET #show" do
     it "returns a success response" do

--- a/spec/factories/opportunities.rb
+++ b/spec/factories/opportunities.rb
@@ -3,7 +3,9 @@ FactoryBot.define do
     sequence(:name) {|i| "Opportunity #{i}"}
     description "Description"
     job_posting_url "https://example.com"
+
     association :employer
+    association :opportunity_type
     
     after(:build) do |opp, evaluator|
       opp.metros << create(:metro) if opp.metros.empty?

--- a/spec/factories/opportunities.rb
+++ b/spec/factories/opportunities.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
     association :employer
     association :opportunity_type
+    association :region
     
     after(:build) do |opp, evaluator|
       opp.metros << create(:metro) if opp.metros.empty?

--- a/spec/factories/opportunity_types.rb
+++ b/spec/factories/opportunity_types.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :opportunity_type do
+    sequence(:name) { |i| "Opportunity Type #{sprintf('%02d', i)}"}
+    sequence(:position) { |i| i }
+  end
+end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :region do
     sequence(:name) { |i| "Region #{i}" }
+    sequence(:position) { |i| i }
   end
 end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :region do
+    sequence(:name) { |i| "Region #{i}" }
+  end
+end

--- a/spec/features/opportunities_views_spec.rb
+++ b/spec/features/opportunities_views_spec.rb
@@ -53,6 +53,7 @@ RSpec.feature "OpportunityViews", type: :feature do
     fill_in 'Phone', with: contact_attributes[:phone]
     fill_in 'Email', with: contact_attributes[:email]
     fill_in 'Url', with: contact_attributes[:url]
+    fill_in 'Job Posting URL', with: opportunity_attributes[:job_posting_url]
     
     expect_list_link_for 'industries/interests', link: 'full list', within: '#interests-collection'
     expect_list_link_for :metro_areas, link: 'full list', within: '#metros-collection'
@@ -64,7 +65,7 @@ RSpec.feature "OpportunityViews", type: :feature do
     click_on 'Create Opportunity'
     opportunity = Opportunity.last
 
-    [:name, :description].each do |attr|
+    [:name, :description, :job_posting_url].each do |attr|
       expect(opportunity.send(attr)).to eq(opportunity_attributes[attr])
     end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Contact, type: :model do
   
   it { should validate_inclusion_of(:state).in_array(Contact::STATES) }
   
-  it_behaves_like "valid url", :url
+  it_behaves_like "valid url", :url, allow_blank: true
   
   ##################
   # Instance methods

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -281,6 +281,7 @@ RSpec.describe Opportunity, type: :model do
     let(:interest) { create :interest, name: 'Interest' }
     let(:industry) { create :industry, name: 'Industry' }
     let(:major) { create :major, name: 'Major' }
+    let(:metro) { create :metro, name: 'Omaha, NE-IA'}
     
     let(:contact) { create :contact, city: 'Lincoln', contactable: location }
     let(:location) { create :location, locateable: opportunity }
@@ -292,6 +293,7 @@ RSpec.describe Opportunity, type: :model do
       opportunity.industries << industry
       opportunity.majors << major
       opportunity.locations << location
+      opportunity.metros << metro
     end
     
     subject { opportunity.csv_fields }
@@ -301,7 +303,7 @@ RSpec.describe Opportunity, type: :model do
     it { expect(subject[1]).to eq(opportunity.employer.name) }
     it { expect(subject[2]).to eq('=HYPERLINK("http://example.com", "CSV Opp")') }
     it { expect(subject[3]).to eq(opportunity.opportunity_type.name) }
-    it { expect(subject[4]).to eq(opportunity.locations.first.contact.city) }
+    it { expect(subject[4]).to eq('Omaha, NE') }
     it { expect(subject[5]).to eq(opportunity.job_posting_url) }
     it { expect(subject[6]).to eq('yes') }
     it { expect(subject[7]).to eq('no') }

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -74,6 +74,15 @@ RSpec.describe Opportunity, type: :model do
     expect(Opportunity.new.steps).to be_an(Array)
   end
   
+  ###############
+  # Class methods
+  ###############
+  
+  describe '#csv_headers' do
+    subject { Opportunity.csv_headers }
+    it { should eq(['Region', 'Employer', 'Position', 'Type', 'City', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests'])}
+  end
+  
   ##################
   # Instance methods
   ##################
@@ -262,5 +271,41 @@ RSpec.describe Opportunity, type: :model do
       expect(opportunity.postal_codes).to include('10001')
       expect(opportunity.postal_codes).to include('10002')
     end
+  end
+  
+  describe '#csv_fields' do
+    let(:employer) { create :employer, employer_partner: true}
+    let(:opportunity) { create :opportunity, employer: employer, inbound: false, recurring: true }
+
+    let(:fellow) { create :fellow }
+    let(:interest) { create :interest, name: 'Interest' }
+    let(:industry) { create :industry, name: 'Industry' }
+    let(:major) { create :major, name: 'Major' }
+    
+    let(:contact) { create :contact, city: 'Lincoln', contactable: location }
+    let(:location) { create :location, locateable: opportunity }
+    
+    before do
+      contact
+      
+      opportunity.interests << interest
+      opportunity.industries << industry
+      opportunity.majors << major
+      opportunity.locations << location
+    end
+    
+    subject { opportunity.csv_fields }
+    
+    it { should be_an(Array) }
+    it { expect(subject[0]).to eq(opportunity.region.name) }
+    it { expect(subject[1]).to eq(opportunity.employer.name) }
+    it { expect(subject[2]).to eq(opportunity.name) }
+    it { expect(subject[3]).to eq(opportunity.opportunity_type.name) }
+    it { expect(subject[4]).to eq(opportunity.locations.first.contact.city) }
+    it { expect(subject[5]).to eq(opportunity.job_posting_url) }
+    it { expect(subject[6]).to eq('yes') }
+    it { expect(subject[7]).to eq('no') }
+    it { expect(subject[8]).to eq('yes') }
+    it { expect(subject[9]).to eq("Industry, Interest, Major") }
   end
 end

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Opportunity, type: :model do
   ##############
 
   it { should belong_to :employer }
+  it { should belong_to :opportunity_type }
   
   it { should have_many :tasks }
   it { should have_many :fellow_opportunities }

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -281,7 +281,6 @@ RSpec.describe Opportunity, type: :model do
     let(:interest) { create :interest, name: 'Interest' }
     let(:industry) { create :industry, name: 'Industry' }
     let(:major) { create :major, name: 'Major' }
-    let(:metro) { create :metro, name: 'Omaha, NE-IA'}
     
     let(:contact) { create :contact, city: 'Lincoln', contactable: location }
     let(:location) { create :location, locateable: opportunity }
@@ -293,7 +292,7 @@ RSpec.describe Opportunity, type: :model do
       opportunity.industries << industry
       opportunity.majors << major
       opportunity.locations << location
-      opportunity.metros << metro
+      opportunity.metros.first.update(name: 'Omaha, NE-IA')
     end
     
     subject { opportunity.csv_fields }

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Opportunity, type: :model do
 
   it { should belong_to :employer }
   it { should belong_to :opportunity_type }
+  it { should belong_to :region }
   
   it { should have_many :tasks }
   it { should have_many :fellow_opportunities }

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -340,18 +340,26 @@ RSpec.describe Opportunity, type: :model do
       it { should eq(2) }
     end
     
+    describe 'when employer_partner AND recurring' do
+      let(:employer_partner) { true }
+      let(:recurring) { true }
+      
+      it { should eq(3) }
+    end
+    
     describe 'when employer_partner' do
       let(:employer_partner) { true }
-      it { should eq(2) }
+      
+      it { should eq(4) }
     end
     
     describe 'when recurring' do
       let(:recurring) { true }
-      it { should eq(3) }
+      it { should eq(5) }
     end
     
     describe 'when none are true' do
-      it { should eq(4) }
+      it { should eq(6) }
     end
   end
 end

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Opportunity, type: :model do
   
   describe '#csv_fields' do
     let(:employer) { create :employer, employer_partner: true}
-    let(:opportunity) { create :opportunity, employer: employer, inbound: false, recurring: true }
+    let(:opportunity) { create :opportunity, employer: employer, inbound: false, recurring: true, job_posting_url: 'http://example.com', name: 'CSV Opp' }
 
     let(:fellow) { create :fellow }
     let(:interest) { create :interest, name: 'Interest' }
@@ -299,7 +299,7 @@ RSpec.describe Opportunity, type: :model do
     it { should be_an(Array) }
     it { expect(subject[0]).to eq(opportunity.region.name) }
     it { expect(subject[1]).to eq(opportunity.employer.name) }
-    it { expect(subject[2]).to eq(opportunity.name) }
+    it { expect(subject[2]).to eq('=HYPERLINK("http://example.com", "CSV Opp")') }
     it { expect(subject[3]).to eq(opportunity.opportunity_type.name) }
     it { expect(subject[4]).to eq(opportunity.locations.first.contact.city) }
     it { expect(subject[5]).to eq(opportunity.job_posting_url) }

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Opportunity, type: :model do
   
   describe '#csv_headers' do
     subject { Opportunity.csv_headers }
-    it { should eq(['Region', 'Employer', 'Position', 'Type', 'City', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests'])}
+    it { should eq(['Region', 'Employer', 'Position', 'Type', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests'])}
   end
   
   ##################

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -308,4 +308,50 @@ RSpec.describe Opportunity, type: :model do
     it { expect(subject[8]).to eq('yes') }
     it { expect(subject[9]).to eq("Industry, Interest, Major") }
   end
+  
+  describe '#priority' do
+    let(:employer) { create :employer, employer_partner: employer_partner }
+    let(:opportunity) { build :opportunity, employer: employer, inbound: inbound, recurring: recurring }
+
+    let(:employer_partner) { false }
+    let(:inbound) { false }
+    let(:recurring) { false }
+    
+    
+    subject { opportunity.priority }
+    
+    describe 'when employer_partner AND inbound AND recurring' do
+      let(:employer_partner) { true }
+      let(:inbound) { true }
+      let(:recurring) { true }
+      
+      it { should eq(0) }
+    end
+    
+    describe 'when employer_partner AND inbound' do
+      let(:employer_partner) { true }
+      let(:inbound) { true }
+
+      it { should eq(1) }
+    end
+    
+    describe 'when inbound' do
+      let(:inbound) { true }
+      it { should eq(2) }
+    end
+    
+    describe 'when employer_partner' do
+      let(:employer_partner) { true }
+      it { should eq(2) }
+    end
+    
+    describe 'when recurring' do
+      let(:recurring) { true }
+      it { should eq(3) }
+    end
+    
+    describe 'when none are true' do
+      it { should eq(4) }
+    end
+  end
 end

--- a/spec/models/opportunity_type_spec.rb
+++ b/spec/models/opportunity_type_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe OpportunityType, type: :model do
+  ##############
+  # Associations
+  ##############
+  
+  it { should have_many :opportunities }
+  
+  #############
+  # Validations
+  #############
+
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:position) }
+  
+  describe 'validating uniqueness' do
+    before { create :opportunity_type }
+    
+    it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:position) }
+  end
+end

--- a/spec/models/opportunity_type_spec.rb
+++ b/spec/models/opportunity_type_spec.rb
@@ -20,4 +20,17 @@ RSpec.describe OpportunityType, type: :model do
     it { should validate_uniqueness_of(:name) }
     it { should validate_uniqueness_of(:position) }
   end
+  
+  ###############
+  # Class methods
+  ###############
+
+  describe '::types' do
+    subject { OpportunityType.types }
+    
+    it { should be_an(Array) }
+    it { expect(subject.size).to eq(9) }
+    it { expect(subject.first).to eq('Internship') }
+    it { expect(subject.last).to eq('Volunteer') }
+  end
 end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -12,9 +12,25 @@ RSpec.describe Region, type: :model do
   #############
 
   it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:position) }
   
   describe 'validating uniqeness' do
     before { create :region }
+
     it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:position) }
+  end
+  
+  ###############
+  # Class methods
+  ###############
+
+  describe '::types' do
+    subject { Region.types }
+    
+    it { should be_an(Array) }
+    it { expect(subject.size).to eq(4) }
+    it { expect(subject.first).to eq('Chicago, IL') }
+    it { expect(subject.last).to eq('Nationwide') }
   end
 end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Region, type: :model do
     
     it { should be_an(Array) }
     it { expect(subject.size).to eq(4) }
-    it { expect(subject.first).to eq('Chicago, IL') }
+    it { expect(subject.first).to eq('Bay') }
     it { expect(subject.last).to eq('Nationwide') }
   end
 end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Region, type: :model do
+  ##############
+  # Associations
+  ##############
+
+  it { should have_many :opportunities }
+  
+  #############
+  # Validations
+  #############
+
+  it { should validate_presence_of(:name) }
+  
+  describe 'validating uniqeness' do
+    before { create :region }
+    it { should validate_uniqueness_of(:name) }
+  end
+end

--- a/spec/routing/admin/opportunities_routing_spec.rb
+++ b/spec/routing/admin/opportunities_routing_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Admin::OpportunitiesController, type: :routing do
     it "routes to #index" do
       expect(:get => "/admin/opportunities").to route_to("admin/opportunities#index")
     end
+    
+    it "routes to #export" do
+      expect(:post => '/admin/opportunities/export').to route_to('admin/opportunities#export')
+    end
 
     it "routes to #show" do
       expect(:get => "/admin/opportunities/1").to route_to("admin/opportunities#show", :id => "1")

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples_for "valid url" do |attribute|
+shared_examples_for "valid url" do |attribute, options={}|
   describe "validating #{attribute} format" do
     it "rejects invalid url" do
       object = described_class.new attribute => 'a b c'
@@ -7,13 +7,22 @@ shared_examples_for "valid url" do |attribute|
       expect(object.errors[attribute]).to include('is an invalid URL')
     end
   
-    it "rejects blank urls" do
-      object = described_class.new
-      object.valid?
+    if options[:allow_blank]
+      it "allows blank urls" do
+        object = described_class.new
+        object.valid?
     
-      expect(object.errors[attribute]).to include('is an invalid URL')
-    end
-  
+        expect(object.errors[attribute]).to_not include('is an invalid URL')
+      end
+    else
+      it "rejects blank urls" do
+        object = described_class.new
+        object.valid?
+    
+        expect(object.errors[attribute]).to include('is an invalid URL')
+      end
+    end  
+    
     it "sets the protocol if missing" do
       url = 'example.com'
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -7,11 +7,11 @@ shared_examples_for "valid url" do |attribute|
       expect(object.errors[attribute]).to include('is an invalid URL')
     end
   
-    it "allows blank urls" do
+    it "rejects blank urls" do
       object = described_class.new
       object.valid?
     
-      expect(object.errors[attribute]).to_not include('is an invalid URL')
+      expect(object.errors[attribute]).to include('is an invalid URL')
     end
   
     it "sets the protocol if missing" do


### PR DESCRIPTION
So many wonderful features:

* employer now has "employer_partner" toggle
* opps now have "inbound" and "recurring" toggles
* opps now have pulldown menus for region and opp type
* opportunities can be exported to a CSV file which is sorted first by region, then by "priority". 

**NEW:**

* The export feature is now a form that allows staff to select which opps to export. Only the previously unpublished opps are checked by default. See second screencap.

Opp priorities, highest to lowest:

1. employer_partner AND inbound AND recurring
2. employer_partner AND inbound
3. employer_partner OR inbound
4. recurring
5. everything else

**screencap**: http://bit.ly/2NovtcQ
**screencap 2, export:** http://bit.ly/2wnT8DG

![20180829-specs](https://user-images.githubusercontent.com/12893/44802623-dbb4f300-ab81-11e8-8570-68321f99a37e.png)
