### PR TITLE
Job Hunter Flash Messages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -425,3 +425,8 @@ ul.inline-list {
   padding-right: 20px;
   margin: 0
 }
+
+div#stage-notice {
+  background: #efe;
+  font-weight: bold;
+}

--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -3,7 +3,12 @@ class CandidatesController < ApplicationController
   
   def status
     if @fellow_opportunity = FellowOpportunity.find_by(id: params[:fellow_opportunity_id])
-      @fellow_opportunity.update_stage(params[:update].downcase, from: params[:from])
+      update = params[:update].downcase
+      notice = @fellow_opportunity.opportunity_stage.content['notices'][update]
+      
+      @fellow_opportunity.update_stage(update, from: params[:from])
+      
+      flash[:stage_notice] = notice if notice
       redirect_to fellow_opportunity_path(@fellow_opportunity)
     else
       fail_token_authorize!

--- a/app/models/fellow_opportunity.rb
+++ b/app/models/fellow_opportunity.rb
@@ -16,6 +16,7 @@ class FellowOpportunity < ApplicationRecord
   
   scope :active, ->{ where(active: true) }
   scope :inactive, -> { where(active: false) }
+  scope :most_neglected, -> { active.order(last_contact_at: :asc) }
   
   def log message
     logs.create status: message

--- a/app/views/fellow/opportunities/show.html.erb
+++ b/app/views/fellow/opportunities/show.html.erb
@@ -33,6 +33,10 @@
             <% completion = 'not-completed' %> 
 
             <td class="stage active-stage phase-<%= phase.downcase %>">
+              <% if flash[:stage_notice] %>
+                <div id="stage-notice"><%= flash[:stage_notice]%></div>
+              <% end %>
+              
               <h3>
                 <%= content['phase_position'] %>. <%= content['title'] %>
               </h3>

--- a/config/opportunity_stage_content.yml
+++ b/config/opportunity_stage_content.yml
@@ -7,6 +7,13 @@ default links: &default_links
 default links with employer: &default_links_with_employer
   <<: *default_links
   employer declined: "Employer Declined"
+  
+default notices: &default_notices
+  next: "Great!"
+  no change: "Okay."
+  skip: "Okay."
+  fellow declined: "Thanks for letting us know."
+  employer declined: "Sorry to hear that."
 
 research employer:
   phase: "Apply"
@@ -21,6 +28,7 @@ research employer:
       - "Better Business Bureau"
       - "Idealist.org (for mission-driven organizations)"
   links: *default_links
+  notices: *default_notices
   burden: "15 minutes"
 
 connect with employees:
@@ -37,6 +45,7 @@ connect with employees:
       - "This step doesn't take a lot of effort but it does take time. We'll send you helpful reminders about it so you stay on track."
       - "PRO TIP: Keep taking feedback and revise your application materials accordingly."
   links: *default_links
+  notices: *default_notices
   burden: "3 hours"
 
 customize application materials:
@@ -53,6 +62,7 @@ customize application materials:
       - "Follow key companies and people in the industry, and join relevant groups and meetups."
       - "PRO TIP: Catch all the typos! Professional polish shows that you care about doing your job well."
   links: *default_links
+  notices: *default_notices
   burden: "30 minutes"
     
 submit application:
@@ -65,6 +75,7 @@ submit application:
       - "Make sure your resume and cover letter are in the appropriate format (PDF unless they ask for something else)."
       - "If you're emailing the application be sure to include a short note thanking the hiring manager for the opportunity to apply."
   links: *default_links
+  notices: *default_notices
   burden: "a couple of minutes"
       
 follow up after application:
@@ -75,6 +86,7 @@ follow up after application:
   tips:
     header: "Follow up with any contacts you have who might have some influence at the company (e.g. current and past employees, partners, clients) by sending them a copy of the resume and cover letter and asking \"Would you be willing to put in a word for me to make sure my application is considered?\""
   links: *default_links_with_employer
+  notices: *default_notices
   burden: "5 minutes"
 
 schedule interview:
@@ -83,6 +95,7 @@ schedule interview:
   phase_position: 1
   question: "Have you scheduled an interview?"
   links: *default_links_with_employer
+  notices: *default_notices
   
 research interview process:
   phase: "Interview"
@@ -96,6 +109,7 @@ research interview process:
       - "Brainstorm what questions they might ask based on what you've learned about them."
       - "PRO TIP: Research what people wear on the actual job so you can dress appropriately for your interview."
   links: *default_links
+  notices: *default_notices
 
 practice for interview:
   phase: "Interview"
@@ -109,6 +123,7 @@ practice for interview:
       - "Prepare 3-5 questions you can ask your interviewer."
       - "Practice with people you know in the field, your campus career center, other Fellows, your Coach, or even friends and family."
   links: *default_links
+  notices: *default_notices
 
 attend interview:
   phase: "Interview"
@@ -122,6 +137,7 @@ attend interview:
       - "Reserve some free time after the interview in case it starts late or goes longer than expected."
       - "PRO TIP: Bring copies of your resume and some business cards."
   links: *default_links
+  notices: *default_notices
 
 follow up after interview:
   phase: "Interview"
@@ -131,6 +147,7 @@ follow up after interview:
   tips:
     header: "Send a quick follow up to express your continued excitement for the opportunity and to follow-up on anything from the interview."
   links: *default_links_with_employer
+  notices: *default_notices
   
 receive offer:
   phase: "Offer"
@@ -142,6 +159,7 @@ receive offer:
     no change: "Not Yet"
     fellow declined: "No Longer Interested"
     employer declined: "Employer Declined"
+  notices: *default_notices
 
 submit counter-offer:
   phase: "Offer"
@@ -158,6 +176,10 @@ submit counter-offer:
     no change: "Not Yet"
     fellow accepted: "Accepted Offer"
     fellow declined: "No Longer Interested"
+  notices:
+    <<: *default_notices
+    receive offer: "Way to Go!"
+    fellow accepted: "Congratulations!"
 
 accept offer:
   phase: "Offer"
@@ -165,3 +187,6 @@ accept offer:
   phase_position: 3
   question: "Have you accepted your offer with <%= @opp.employer.name %>?"
   links: *default_links
+  notices:
+    <<: *default_notices
+    next: "Congratulations!"

--- a/spec/controllers/candidates_controller_spec.rb
+++ b/spec/controllers/candidates_controller_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe CandidatesController, type: :controller do
+  let(:previous_stage) { create :opportunity_stage, name: 'offered' }
   let(:opportunity_stage) { create :opportunity_stage, name: 'accepted' }
   
   let(:access_token) { create :access_token, code: code, routes: route_list }
   let(:code) { 'aaaabbbbccccdddd' }
   let(:route_list) { [{'label' => 'status', 'method' => 'GET', 'params' => {'controller' => 'candidates', 'action' => 'status', 'fellow_opportunity_id' => fellow_opportunity.id.to_s, 'update' => /^(submitted|accepted|declined)$/}}] }
   
-  let(:fellow_opportunity) { create :fellow_opportunity, fellow: fellow, opportunity: opportunity }
+  let(:fellow_opportunity) { create :fellow_opportunity, fellow: fellow, opportunity: opportunity, opportunity_stage: previous_stage }
   let(:fellow) { create :fellow }
   let(:opportunity) { create :opportunity }
   
@@ -16,6 +17,10 @@ RSpec.describe CandidatesController, type: :controller do
   end
   
   describe "GET #status" do
+    before do
+      allow_any_instance_of(OpportunityStage).to receive(:content).and_return({'notices' => {'accepted' => 'Congrats!'}})
+    end 
+    
     it "redirects without token" do
       get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted'}
 
@@ -45,6 +50,11 @@ RSpec.describe CandidatesController, type: :controller do
     it "updates the fellow_opportunity stage" do
       get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted', token: access_token.code}
       expect(fellow_opportunity.reload.stage).to eq('accepted')
+    end
+    
+    it "sets the flash notice" do
+      get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted', token: access_token.code}
+      expect(flash[:stage_notice]).to eq('Congrats!')
     end
   end
 end

--- a/spec/models/fellow_opportunity_spec.rb
+++ b/spec/models/fellow_opportunity_spec.rb
@@ -55,6 +55,30 @@ RSpec.describe FellowOpportunity, type: :model do
     end
   end
   
+  describe 'most_neglected' do
+    let(:recent) { create :fellow_opportunity, active: true, last_contact_at: 1.minute.ago }
+    let(:neglected) { create :fellow_opportunity, active: true, last_contact_at: 1.year.ago }
+    let(:inactive) { create :fellow_opportunity, active: false }
+    
+    before do
+      recent; neglected; inactive
+    end
+
+    subject { FellowOpportunity.most_neglected }
+    
+    it "contains the neglected opp first" do
+      expect(subject.first).to eq(neglected)
+    end
+    
+    it "contains the recently updated opp last" do
+      expect(subject.last).to eq(recent)
+    end
+    
+    it "does not contain the inactive opp" do
+      expect(subject).to_not include(inactive)
+    end
+  end
+  
   ##################
   # Instance methods
   ##################


### PR DESCRIPTION
The opportunity_stages.yml file now includes a place for "flash notice" messages, which appear within the active opportunity stage for a candidate ONCE after they've updated their status. 

**UPDATE:** there is now a "most neglected" helper scope for fellow opportunities. It can be called like so:

    # for all fellow opportunities
    FellowOpportunity.most_neglected

    # for just this candidate's opportunities
    @fellow.fellow_opportunities.most_neglected

It returns a list of fellow opps that are both ACTIVE and sorted from most "neglected" to least - so the opps that the fellow hasn't updated in a long time appear nearest the top of the list.

![20180828-specs](https://user-images.githubusercontent.com/12893/44738502-bb6e3100-aaba-11e8-961e-e1cc8e4a45c7.png)

