### PR TITLE
N-Tier Location Tags

### DIFF
--- a/app/models/metro.rb
+++ b/app/models/metro.rb
@@ -44,4 +44,14 @@ class Metro < ApplicationRecord
     
     state_list.split('-')
   end
+  
+  def all_parents
+    return [] if parents.empty?
+    (parents + parents.map(&:all_parents).flatten).compact
+  end
+  
+  def all_children
+    return [] if children.empty?
+    (children + children.map(&:all_children).flatten).compact
+  end
 end

--- a/app/models/metro.rb
+++ b/app/models/metro.rb
@@ -1,6 +1,9 @@
 class Metro < ApplicationRecord
   has_and_belongs_to_many :opportunities
   has_and_belongs_to_many :fellows
+  
+  has_and_belongs_to_many :parents, class_name: 'Metro', join_table: 'metro_relationships', foreign_key: 'parent_id', association_foreign_key: 'child_id'
+  has_and_belongs_to_many :children, class_name: 'Metro', join_table: 'metro_relationships', foreign_key: 'child_id', association_foreign_key: 'parent_id'
 
   validates :code, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: true

--- a/app/models/metro.rb
+++ b/app/models/metro.rb
@@ -5,7 +5,7 @@ class Metro < ApplicationRecord
   validates :code, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: true
   
-  scope :city, ->{ where.not(source: 'ST') }
+  scope :city, ->{ where.not(source: ['ST', 'ANY']) }
   scope :state, ->{ where(source: 'ST') }
 
   class << self

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -91,16 +91,18 @@ class Opportunity < ApplicationRecord
   end
   
   def fellow_ids_for_metros names
-    selected_ids = if names
-      Metro.where(name: names.split(';')).pluck(:id)
+    named = if names
+      Metro.where(name: names.split(';'))
     else
-      metro_ids
+      metros
     end
     
-    state_ids = state_ids_for_metro_ids(selected_ids)
-    city_ids = metro_ids_for_state_ids(selected_ids)
+    parent_ids = named.map(&:all_parents).flatten.uniq.map(&:id)
+    child_ids = named.map(&:all_children).flatten.uniq.map(&:id)
     
-    FellowMetro.fellow_ids_for(selected_ids + state_ids + city_ids)
+    selected_ids = (named.pluck(:id) + parent_ids + child_ids).uniq
+    
+    FellowMetro.fellow_ids_for(selected_ids)
   end
   
   def state_ids_for_metro_ids metro_ids

--- a/db/migrate/20180828211232_more_explicit_state_names.rb
+++ b/db/migrate/20180828211232_more_explicit_state_names.rb
@@ -1,0 +1,15 @@
+class MoreExplicitStateNames < ActiveRecord::Migration[5.2]
+  def up
+    Metro.state.each do |metro|
+      next if metro.name =~ /\(Statewide\)$/
+      metro.update name: "#{metro.name} (Statewide)"
+    end
+  end
+  
+  def down
+    Metro.state.each do |metro|
+      next unless metro.name =~ /\(Statewide\)$/
+      metro.update name: metro.name.match(/^(.*)\s+\(Statewide\)/)[1]
+    end
+  end
+end

--- a/db/migrate/20180828211901_add_anywhere_metro_tag.rb
+++ b/db/migrate/20180828211901_add_anywhere_metro_tag.rb
@@ -1,0 +1,17 @@
+class AddAnywhereMetroTag < ActiveRecord::Migration[5.2]
+  def tag_name
+    'Anywhere'
+  end
+  
+  def up
+    unless Metro.find_by(name: tag_name)
+      Metro.create! code: 'ANY', name: tag_name, source: 'TOP'
+    end
+  end
+  
+  def down
+    if tag = Metro.find_by(name: tag_name)
+      tag.destroy
+    end
+  end
+end

--- a/db/migrate/20180828220203_create_metro_relationships.rb
+++ b/db/migrate/20180828220203_create_metro_relationships.rb
@@ -1,0 +1,12 @@
+class CreateMetroRelationships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :metro_relationships, id: false do |t|
+      t.integer :parent_id
+      t.integer :child_id
+    end
+    
+    add_index :metro_relationships, [:parent_id, :child_id]
+    add_index :metro_relationships, :parent_id
+    add_index :metro_relationships, :child_id
+  end
+end

--- a/db/migrate/20180828221845_add_metro_associations.rb
+++ b/db/migrate/20180828221845_add_metro_associations.rb
@@ -1,0 +1,35 @@
+class AddMetroAssociations < ActiveRecord::Migration[5.2]
+  def remove_associations
+    ActiveRecord::Base.connection.execute('delete from metro_relationships;')
+  end
+  
+  def pacifier
+    print '.'
+    $stdout.flush
+  end
+  
+  def up
+    remove_associations
+    
+    anywhere = Metro.find_by(name: 'Anywhere')
+    
+    Metro.state.each do |state|
+      pacifier
+      state.parents << anywhere
+    end
+    
+    Metro.city.each do |city|
+      city.states.each do |code|
+        pacifier
+        state = Metro.find_by(code: code)
+        city.parents << state if state
+      end
+    end
+    
+    puts
+  end
+  
+  def down
+    remove_associations
+  end
+end

--- a/db/migrate/20180829174336_add_remote_metro_tag.rb
+++ b/db/migrate/20180829174336_add_remote_metro_tag.rb
@@ -1,0 +1,31 @@
+class AddRemoteMetroTag < ActiveRecord::Migration[5.2]
+  def tag_name
+    'Remote'
+  end
+  
+  def pacifier
+    print '.'
+    $stdout.flush
+  end
+  
+  def up
+    unless Metro.find_by(name: tag_name)
+      Metro.create! code: 'REM', name: tag_name, source: 'TOP'
+    end
+
+    remote = Metro.find_by(name: tag_name)
+    
+    Metro.state.each do |state|
+      pacifier
+      state.parents << remote
+    end
+    
+    puts
+  end
+  
+  def down
+    if tag = Metro.find_by(name: tag_name)
+      tag.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_28_221845) do
+ActiveRecord::Schema.define(version: 2018_08_29_174336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,9 +335,11 @@ ActiveRecord::Schema.define(version: 2018_08_28_221845) do
     t.boolean "recurring", default: false
     t.integer "opportunity_type_id"
     t.integer "region_id"
+    t.boolean "published", default: false
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"
+    t.index ["published"], name: "index_opportunities_on_published"
     t.index ["recurring"], name: "index_opportunities_on_recurring"
     t.index ["region_id"], name: "index_opportunities_on_region_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_08_193539) do
+ActiveRecord::Schema.define(version: 2018_08_28_211232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,8 @@ ActiveRecord::Schema.define(version: 2018_08_08_193539) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "employer_partner", default: false
+    t.index ["employer_partner"], name: "index_employers_on_employer_partner"
     t.index ["name"], name: "index_employers_on_name", unique: true
   end
 
@@ -321,7 +323,15 @@ ActiveRecord::Schema.define(version: 2018_08_08_193539) do
     t.string "job_posting_url"
     t.date "application_deadline"
     t.text "steps"
+    t.boolean "inbound", default: false
+    t.boolean "recurring", default: false
+    t.integer "opportunity_type_id"
+    t.integer "region_id"
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
+    t.index ["inbound"], name: "index_opportunities_on_inbound"
+    t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"
+    t.index ["recurring"], name: "index_opportunities_on_recurring"
+    t.index ["region_id"], name: "index_opportunities_on_region_id"
   end
 
   create_table "opportunity_stages", force: :cascade do |t|
@@ -337,6 +347,15 @@ ActiveRecord::Schema.define(version: 2018_08_08_193539) do
     t.index ["togglable"], name: "index_opportunity_stages_on_togglable"
   end
 
+  create_table "opportunity_types", force: :cascade do |t|
+    t.string "name"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_opportunity_types_on_name"
+    t.index ["position"], name: "index_opportunity_types_on_position"
+  end
+
   create_table "postal_codes", force: :cascade do |t|
     t.string "code"
     t.decimal "latitude", precision: 10, scale: 6
@@ -345,6 +364,15 @@ ActiveRecord::Schema.define(version: 2018_08_08_193539) do
     t.datetime "updated_at", null: false
     t.string "msa_code"
     t.index ["code"], name: "index_postal_codes_on_code"
+  end
+
+  create_table "regions", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "position"
+    t.index ["name"], name: "index_regions_on_name"
+    t.index ["position"], name: "index_regions_on_position"
   end
 
   create_table "sites", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_28_211232) do
+ActiveRecord::Schema.define(version: 2018_08_28_211901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_28_211901) do
+ActiveRecord::Schema.define(version: 2018_08_28_220203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -292,6 +292,14 @@ ActiveRecord::Schema.define(version: 2018_08_28_211901) do
     t.bigint "opportunity_id", null: false
     t.index ["major_id", "opportunity_id"], name: "index_majors_opportunities_on_major_id_and_opportunity_id"
     t.index ["opportunity_id", "major_id"], name: "index_majors_opportunities_on_opportunity_id_and_major_id"
+  end
+
+  create_table "metro_relationships", id: false, force: :cascade do |t|
+    t.integer "parent_id"
+    t.integer "child_id"
+    t.index ["child_id"], name: "index_metro_relationships_on_child_id"
+    t.index ["parent_id", "child_id"], name: "index_metro_relationships_on_parent_id_and_child_id"
+    t.index ["parent_id"], name: "index_metro_relationships_on_parent_id"
   end
 
   create_table "metros", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_28_220203) do
+ActiveRecord::Schema.define(version: 2018_08_28_221845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/metro_spec.rb
+++ b/spec/models/metro_spec.rb
@@ -105,4 +105,50 @@ RSpec.describe Metro, type: :model do
       expect(metro.states).to include('IA')
     end
   end
+
+  describe 'ancestry' do
+    let(:unrelated) { create :metro }
+    let(:grandparent) { create :metro }
+    let(:parent) { create :metro }
+    let(:child) { create :metro }
+    let(:sibling) { create :metro }
+    let(:uncle) { create :metro }
+    let(:cousin) { create :metro }
+  
+    before do
+      grandparent.children << parent
+      grandparent.children << uncle
+      
+      parent.children << child
+      parent.children << sibling
+      
+      uncle.children << cousin
+      
+      unrelated
+    end
+  
+    describe '#all_parents' do
+      subject { child.all_parents }
+    
+      it { should_not include(child) }
+      it { should include(parent) }
+      it { should include(grandparent) }
+      it { should_not include(uncle) }
+      it { should_not include(sibling) }
+      it { should_not include(cousin) }
+      it { should_not include(unrelated) }
+    end
+  
+    describe '#all_children' do
+      subject { grandparent.all_children }
+    
+      it { should include(child) }
+      it { should include(parent) }
+      it { should include(uncle) }
+      it { should include(sibling) }
+      it { should include(cousin) }
+      it { should_not include(grandparent) }
+      it { should_not include(unrelated) }
+    end
+  end
 end

--- a/spec/models/metro_spec.rb
+++ b/spec/models/metro_spec.rb
@@ -22,6 +22,37 @@ RSpec.describe Metro, type: :model do
     it { should validate_uniqueness_of(:name) }
   end
   
+  ########
+  # Scopes
+  ########
+
+  describe 'city/state scopes' do
+    let(:city1) { create :metro, source: 'MSA' }
+    let(:city2) { create :metro, source: 'SMSA' }
+    let(:state) { create :metro, source: 'ST' }
+    let(:anywhere) { create :metro, source: 'ANY' }
+    
+    before { city1; city2; state; anywhere }
+    
+    describe 'city' do
+      subject { Metro.city }
+      
+      it { should include(city1) }
+      it { should include(city2) }
+      it { should_not include (state) }
+      it { should_not include(anywhere) }
+    end
+    
+    describe 'state' do
+      subject { Metro.state }
+      
+      it { should_not include(city1) }
+      it { should_not include(city2) }
+      it { should include (state) }
+      it { should_not include(anywhere) }
+    end
+  end
+  
   ###############
   # Class methods
   ###############

--- a/spec/models/metro_spec.rb
+++ b/spec/models/metro_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Metro, type: :model do
   it { should have_and_belong_to_many :opportunities }
   it { should have_and_belong_to_many :fellows }
   
+  it { should have_and_belong_to_many :parents }
+  it { should have_and_belong_to_many :children }
+  
   #############
   # Validations
   #############


### PR DESCRIPTION
Woohoo for recursive functions! Our "metro areas", which are now really just location tags, now have many-to-many parent/child relationships. A tag can have many children (ie, nebraska has lincoln and omaha), and tags can have multiple parents (ie, kansas city belongs to both kansas and missouri). This allows us to introduce two new (identical) tags: Anywhere and Remote.

These tags sit at the top of the hierarchy, and match everything below them. So a fellow with an accounting interest, who marks "anywhere" for their location of choice, will show up in searches for accounting opportunties located...you guessed it...anywhere.

As the screencap mentions, this opens the doors to things like adding regions and countries in the future, since we're no longer restricted to a 2-tier, city/state tag structure.

**screencap:** http://bit.ly/2PekSBJ

![20180829-specs](https://user-images.githubusercontent.com/12893/44806177-db215a00-ab8b-11e8-8318-6eff596345c4.png)
