### PR TITLE
Safe staging mailing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,10 +56,6 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
-group :development, :test, :staging do
-  gem 'safety_mailer'
-end
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -97,3 +93,4 @@ gem 'delayed_job_active_record'
 
 gem 'devise'
 gem 'devise_cas_authenticatable'
+gem 'safety_mailer'

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,10 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+group :development, :test, :staging do
+  gem 'safety_mailer'
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
     rubycas-client (2.3.9)
       activesupport
     rubyzip (1.2.1)
+    safety_mailer (0.0.10)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -349,6 +350,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.0)
   rspec-rails (~> 3.6)
+  safety_mailer
   sass-rails (~> 5.0)
   selenium-webdriver (~> 3.7)
   shoulda-matchers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,16 +66,21 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = {host: 'career.bebraven.org'}
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address:              Rails.application.secrets.smtp_server,
-    port:                 587,
-    domain:               Rails.application.secrets.smtp_domain,
-    user_name:            Rails.application.secrets.smtp_username,
-    password:             Rails.application.secrets.smtp_password,
-    authentication:       'login',
-    default_name:         'Braven Careers',
-    enable_starttls_auto: true }
+  config.action_mailer.delivery_method = :safety_mailer
+  config.action_mailer.safety_mailer_settings = {
+    allowed_matchers: [/@/],
+    delivery_method: :smtp,
+    delivery_method_settings: {
+      address:              Rails.application.secrets.smtp_server,
+      port:                 587,
+      domain:               Rails.application.secrets.smtp_domain,
+      user_name:            Rails.application.secrets.smtp_username,
+      password:             Rails.application.secrets.smtp_password,
+      authentication:       'login',
+      default_name:         'Braven Careers',
+      enable_starttls_auto: true
+    }
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -37,7 +37,22 @@ Rails.application.configure do
   
   config.action_mailer.default_url_options = {host: 'localhost', port: 3010}
   config.action_mailer.show_previews = true
-  config.action_mailer.delivery_method = :test
+
+  config.action_mailer.delivery_method = :safety_mailer
+  config.action_mailer.safety_mailer_settings = {
+    allowed_matchers: [/@bebraven\.org$/, /@beyondz\.org/],
+    delivery_method: :smtp,
+    delivery_method_settings: {
+      address:              Rails.application.secrets.smtp_server,
+      port:                 587,
+      domain:               Rails.application.secrets.smtp_domain,
+      user_name:            Rails.application.secrets.smtp_username,
+      password:             Rails.application.secrets.smtp_password,
+      authentication:       'login',
+      default_name:         'Braven Careers',
+      enable_starttls_auto: true
+    }
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_29_145401) do
+ActiveRecord::Schema.define(version: 2018_08_29_174336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This implements safe mailing for staging, only sending to Braven recipients even if other e-mails are in the system (copied over from production). In sticking with our goal of having prod/staging be as close as possible, production will also be using safety_mailer, but with no restrictions on the e-mails being sent.

**This will need to be tested in staging before production deploy, because it's environment-specific.**

![20180830-specs](https://user-images.githubusercontent.com/12893/44868047-2fd9d900-ac4f-11e8-918a-ce627384a896.png)
