### PR TITLE
Unsubscribe Function for Mailers

### DIFF
--- a/app/controllers/admin/fellows_controller.rb
+++ b/app/controllers/admin/fellows_controller.rb
@@ -95,9 +95,8 @@ class Admin::FellowsController < ApplicationController
         :key, :first_name, :last_name, :graduation_year, :graduation_semester, :graduation_fiscal_year, 
         :interests_description, :major, :affiliations, :gpa, :linkedin_url, :staff_notes, :efficacy_score, 
         :employment_status_id, :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
-        industry_ids: [], 
-        interest_ids: [],
-        metro_ids: [],
+        :receive_opportunities,
+        industry_ids: [], interest_ids: [], metro_ids: [],
         contact_attributes: [:id, :address_1, :address_2, :city, :state, :postal_code, :phone, :email, :url]
       )
     end

--- a/app/controllers/fellow/profiles_controller.rb
+++ b/app/controllers/fellow/profiles_controller.rb
@@ -22,7 +22,7 @@ class Fellow::ProfilesController < ApplicationController
   def fellow_params
     params.require(:fellow).permit(
       :key, :first_name, :last_name, :graduation_year, :graduation_semester,
-      :major, :affiliations, :linkedin_url,
+      :major, :affiliations, :linkedin_url, :receive_opportunities,
       :employment_status_id, :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
       industry_ids: [], interest_ids: [], metro_ids: [],
       contact_attributes: [:id, :address_1, :address_2, :city, :state, :postal_code, :phone, :email, :url]

--- a/app/controllers/fellow/profiles_controller.rb
+++ b/app/controllers/fellow/profiles_controller.rb
@@ -17,6 +17,10 @@ class Fellow::ProfilesController < ApplicationController
     end
   end
   
+  def unsubscribe
+    @fellow.ignore_opportunities!
+  end
+  
   private
   
   def fellow_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,10 @@ module ApplicationHelper
     link_to_access_token(@token, 'status', title: title, params: {from: from, update: update}, class: 'button')
   end
   
+  def link_to_unsubscribe fellow
+    link_to('Unsubscribe', AccessToken.for(fellow).path_with_token('Unsubscribe')).html_safe
+  end
+  
   def interpolate string
     ERB.new(string || '').result(binding)
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,14 @@
 class ApplicationMailer < ActionMailer::Base
   default from: Rails.application.secrets.mailer_from_email
   layout 'mailer'
+  
+  private
+  
+  def mail_subscribed subscribed, params={}
+    if subscribed
+      mail(params)
+    else
+      Rails.logger.info("COULD NOT E-MAIL #{params[:to]} due to subscription preferences")
+    end
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,11 +2,15 @@ class ApplicationMailer < ActionMailer::Base
   default from: Rails.application.secrets.mailer_from_email
   layout 'mailer'
   
-  private
+  alias_method :direct_mail, :mail
+  
+  def mail options={}
+    raise "Do not use the mail method directly, use mail_subscribed to prevent mailing unsubscribers."
+  end
   
   def mail_subscribed subscribed, params={}
     if subscribed
-      mail(params)
+      direct_mail(params)
     else
       Rails.logger.info("COULD NOT E-MAIL #{params[:to]} due to subscription preferences")
     end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -3,7 +3,7 @@ class CandidateMailer < ApplicationMailer
 
   def respond_to_invitation
     set_objects
-    mail(to: @fellow.contact.email, subject: "You've been invited to apply for #{@opp.name}")
+    mail_subscribed(@fellow.receive_opportunities, to: @fellow.contact.email, subject: "You've been invited to apply for #{@opp.name}")
   end
   
   def notify
@@ -12,7 +12,7 @@ class CandidateMailer < ApplicationMailer
     @opportunity_stage = OpportunityStage.find_by(name: params[:stage_name])
     @content = @opportunity_stage.content
 
-    mail(to: @fellow.contact.email, subject: "#{@opp.name}: #{@content['title']}")
+    mail_subscribed(@fellow.receive_opportunities, to: @fellow.contact.email, subject: "#{@opp.name}: #{@content['title']}")
   end
   
   private

--- a/app/mailers/fellow_mailer.rb
+++ b/app/mailers/fellow_mailer.rb
@@ -5,6 +5,6 @@ class FellowMailer < ApplicationMailer
     @token = params[:access_token]
     @fellow = @token.owner
     
-    mail(to: @fellow.contact.email, subject: "Please Update Your Profile")
+    mail_subscribed(@fellow.receive_opportunities, to: @fellow.contact.email, subject: "Please Update Your Profile")
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -39,7 +39,8 @@ class AccessToken < ApplicationRecord
       [
         {label: 'view', method: 'GET', params: {controller: 'admin/fellows', action: 'show', id: fellow.id.to_s}},
         {label: 'Edit Your Profile', method: 'GET', params: {controller: 'fellows', action: 'edit', id: fellow.id.to_s}},
-        {label: 'Update Your Profile', method: 'PUT', params: {controller: 'fellows', action: 'update', id: fellow.id.to_s}}
+        {label: 'Update Your Profile', method: 'PUT', params: {controller: 'fellows', action: 'update', id: fellow.id.to_s}},
+        {label: 'Unsubscribe', method: 'GET', params: {controller: 'fellow/profile', action: 'unsubscribe'}}
       ]
     end
     

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -40,7 +40,7 @@ class AccessToken < ApplicationRecord
         {label: 'view', method: 'GET', params: {controller: 'admin/fellows', action: 'show', id: fellow.id.to_s}},
         {label: 'Edit Your Profile', method: 'GET', params: {controller: 'fellows', action: 'edit', id: fellow.id.to_s}},
         {label: 'Update Your Profile', method: 'PUT', params: {controller: 'fellows', action: 'update', id: fellow.id.to_s}},
-        {label: 'Unsubscribe', method: 'GET', params: {controller: 'fellow/profile', action: 'unsubscribe'}}
+        {label: 'Unsubscribe', method: 'GET', params: {controller: 'fellow/profiles', action: 'unsubscribe'}}
       ]
     end
     

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -149,6 +149,14 @@ class Fellow < ApplicationRecord
     career_steps.where(position: positions).update_all(completed: true)
   end
   
+  def receive_opportunities!
+    update receive_opportunities: true
+  end
+  
+  def ignore_opportunities!
+    update receive_opportunities: false
+  end
+  
   private
   
   def generate_key

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -34,6 +34,8 @@ class Fellow < ApplicationRecord
   after_create :generate_career_steps
   after_save :attempt_fellow_match, if: :missing_user?
   
+  scope :receive_opportunities, -> { where(receive_opportunities: true) }
+  
   class << self
     def import contents
       CSV.new(contents, headers: true, skip_lines: /(Anticipated Graduation|STUDENT INFORMATION)/).each do |data|

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -34,7 +34,7 @@ class Opportunity < ApplicationRecord
     search_params ||= {}
     return @candidates if defined?(@candidates)
     
-    candidate_ids = Fellow.pluck(:id)
+    candidate_ids = Fellow.receive_opportunities.pluck(:id)
     
     unless search_params[:industries_interests] == ''
       candidate_ids &= fellow_ids_for_industries_interests(search_params[:industries_interests])

--- a/app/views/admin/fellows/_form.html.erb
+++ b/app/views/admin/fellows/_form.html.erb
@@ -71,6 +71,11 @@
     <%= form.collection_select(:employment_status_id, EmploymentStatus.all, :id, :name) %>
   </div>
   
+  <div class="field">
+    <%= form.check_box :receive_opportunities %>
+    <%= form.label :receive_opportunities, 'Receive Career Opportunties from Braven?', class: 'checkbox' %>
+  </div>
+  
   <hr>
 
   <%= render 'admin/contacts/nested_form', form: form %>

--- a/app/views/admin/fellows/show.html.erb
+++ b/app/views/admin/fellows/show.html.erb
@@ -55,6 +55,10 @@
       <th>Employment status:</th>
       <td><%= @fellow.employment_status.name %></td>
     </tr>
+    <tr>
+      <th>Contact about Opportunities:</th>
+      <td><%= @fellow.receive_opportunities ? 'yes' : 'no' %></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/views/fellow/profiles/_form.html.erb
+++ b/app/views/fellow/profiles/_form.html.erb
@@ -62,6 +62,11 @@
     <%= form.label :employment_status_id %>
     <%= form.collection_select(:employment_status_id, EmploymentStatus.all, :id, :name) %>
   </div>
+  
+  <div class="field">
+    <%= form.check_box :receive_opportunities %>
+    <%= form.label :receive_opportunities, 'Receive Career Opportunties from Braven?', class: 'checkbox' %>
+  </div>
 
   <h3 id="info-interests">Industries and Interests</h3>
   

--- a/app/views/fellow/profiles/show.html.erb
+++ b/app/views/fellow/profiles/show.html.erb
@@ -42,6 +42,10 @@
       <th>Employment status:</th>
       <td><%= @fellow.employment_status.name %></td>
     </tr>
+    <tr>
+      <th>Receive career opportunities from Braven?</th>
+      <td><%= @fellow.receive_opportunities ? 'yes' : 'no' %></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/views/fellow/profiles/unsubscribe.html.erb
+++ b/app/views/fellow/profiles/unsubscribe.html.erb
@@ -1,0 +1,3 @@
+<h1>Thank you</h1>
+
+<p>You will no longer receive e-mails about job opportunities in our network.</p>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -43,10 +43,23 @@
       ul.response-links li {
         padding: 10px 0;
       }
+      
+      .unsubscribe {
+        margin-top: 40px;
+        text-align: center;
+        color: aaa;
+        font-size: smaller;
+      }
     </style>
   </head>
 
   <body>
     <%= yield %>
+    
+    <div class="unsubscribe">
+      <hr>
+      <%= link_to_unsubscribe(@fellow) %>
+      from notifications about future opportunities.
+    </p>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,10 @@ Rails.application.routes.draw do
     get 'home/welcome'
     post 'home/career'
     
-    resource :profile, only: [:show, :edit, :update]
+    resource :profile, only: [:show, :edit, :update] do
+      get :unsubscribe
+    end
+    
     resources :opportunities, only: [:show, :update]
   end
 

--- a/db/migrate/20180904152137_add_receive_opportunities_to_fellows.rb
+++ b/db/migrate/20180904152137_add_receive_opportunities_to_fellows.rb
@@ -1,0 +1,6 @@
+class AddReceiveOpportunitiesToFellows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :fellows, :receive_opportunities, :boolean, default: true
+    add_index :fellows, :receive_opportunities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_29_174336) do
+ActiveRecord::Schema.define(version: 2018_09_04_152137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -199,8 +199,10 @@ ActiveRecord::Schema.define(version: 2018_08_29_174336) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.boolean "receive_opportunities", default: true
     t.index ["employment_status_id"], name: "index_fellows_on_employment_status_id"
     t.index ["key"], name: "index_fellows_on_key", unique: true
+    t.index ["receive_opportunities"], name: "index_fellows_on_receive_opportunities"
     t.index ["user_id"], name: "index_fellows_on_user_id"
   end
 

--- a/spec/controllers/admin/fellows_controller_spec.rb
+++ b/spec/controllers/admin/fellows_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Admin::FellowsController, type: :controller do
   describe "PUT #update" do
     context "with valid params" do
       let(:new_first_name) { valid_attributes[:first_name] + ' 2' }
-      let(:new_attributes) { {first_name: new_first_name} }
+      let(:new_attributes) { {first_name: new_first_name, receive_opportunities: false} }
 
       it "updates the requested fellow" do
         fellow = Fellow.create! valid_attributes
@@ -151,6 +151,7 @@ RSpec.describe Admin::FellowsController, type: :controller do
         fellow.reload
         
         expect(fellow.first_name).to eq(new_first_name)
+        expect(fellow.receive_opportunities).to eq(false)
       end
 
       it "redirects to the fellow" do

--- a/spec/controllers/fellow/profiles_controller_spec.rb
+++ b/spec/controllers/fellow/profiles_controller_spec.rb
@@ -65,4 +65,18 @@ RSpec.describe Fellow::ProfilesController, type: :controller do
       end
     end
   end
+
+  describe "GET #unsubscribe" do
+    it "returns a success response" do
+      get :unsubscribe, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+
+    it "returns a success response" do
+      get :unsubscribe, params: {}, session: valid_session
+      fellow.reload
+      
+      expect(fellow.receive_opportunities).to eq(false)
+    end
+  end
 end

--- a/spec/controllers/fellow/profiles_controller_spec.rb
+++ b/spec/controllers/fellow/profiles_controller_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe Fellow::ProfilesController, type: :controller do
         
         expect(fellow.last_name).to eq(new_last_name)
       end
+      
+      it "updates the receive_opportunities flag" do
+        put :update, params: {fellow: {receive_opportunities: false}}, session: valid_session
+        fellow.reload
+        
+        expect(fellow.receive_opportunities).to eq(false)
+      end
 
       it "redirects to the industries list" do
         put :update, params: {fellow: {last_name: new_last_name}}, session: valid_session

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
   
+  describe 'link_to_unsubscribe' do
+    let(:fellow) { create :fellow }
+    let(:access_token) { AccessToken.for(fellow) }
+    
+    it "links to unsubscribe" do
+      access_token
+      expect(link_to_unsubscribe(fellow)).to eq(link_to('Unsubscribe', "http://localhost:3011/fellow/profile/unsubscribe?token=#{access_token.code}".html_safe))
+    end
+  end
+  
   describe 'interpolate' do
     it "uses ERB interpolation" do
       @answer = 'three'

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe CandidateMailer, type: :mailer do
   let(:access_token) { AccessToken.for(fellow_opportunity) }
 
   let(:fellow_opportunity) { create :fellow_opportunity, fellow: fellow, opportunity: opportunity, opportunity_stage: opportunity_stage }
-  let(:fellow) { create :fellow, contact: create(:contact, email: email) }
+  let(:fellow) { create :fellow, receive_opportunities: receive_opportunities, contact: create(:contact, email: email) }
   let(:email) { 'test@example.com' }
   let(:opportunity) { create :opportunity, name: "New Opportunity" }
   let(:opportunity_stage) { create :opportunity_stage, name: stage_name }
   let(:stage_name) { view.to_s.gsub('_', ' ') }
+  let(:receive_opportunities) { true }
 
   let(:mail) { CandidateMailer.with(access_token: access_token, stage_name: stage_name).send(view) }
   
@@ -31,6 +32,18 @@ RSpec.describe CandidateMailer, type: :mailer do
         expect(mail.body.encoded).to include("http://localhost:3011/candidates/#{fellow_opportunity.id}/status?from=#{from.gsub(' ', '+')}&token=#{access_token.code}&update=#{label.gsub(' ', '+')}")
       end
     end
+    
+    def skips_unsubscribed
+      describe 'when user is unsubscribed from receiving opportunities' do
+        let(:receive_opportunities) { false }
+
+        it "does not send the mailer" do
+          expect {
+            mail.deliver
+          }.to_not change(ActionMailer::Base.deliveries, :count) 
+        end
+      end
+    end
   end
   
   describe 'respond to invitation' do
@@ -43,6 +56,8 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     expect_status_link 'respond to invitation', 'research employer'
     expect_status_link 'respond to invitation', 'fellow decline'
+    
+    skips_unsubscribed
   end
   
   describe 'via notify mailer' do
@@ -59,6 +74,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'research employer', 'no change'
       expect_status_link 'research employer', 'skip'
       expect_status_link 'research employer', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'connect with employees' do
@@ -71,6 +88,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'connect with employees', 'no change'
       expect_status_link 'connect with employees', 'skip'
       expect_status_link 'connect with employees', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'customize application materials' do
@@ -83,6 +102,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'customize application materials', 'no change'
       expect_status_link 'customize application materials', 'skip'
       expect_status_link 'customize application materials', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'submit application' do
@@ -95,6 +116,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'submit application', 'no change'
       expect_status_link 'submit application', 'skip'
       expect_status_link 'submit application', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'follow up after application' do
@@ -108,6 +131,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'follow up after application', 'skip'
       expect_status_link 'follow up after application', 'fellow declined'
       expect_status_link 'follow up after application', 'employer declined'
+      
+      skips_unsubscribed
     end
 
     describe 'schedule interview' do
@@ -121,6 +146,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'schedule interview', 'skip'
       expect_status_link 'schedule interview', 'fellow declined'
       expect_status_link 'schedule interview', 'employer declined'
+      
+      skips_unsubscribed
     end
 
     describe 'research interview process' do
@@ -133,6 +160,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'research interview process', 'no change'
       expect_status_link 'research interview process', 'skip'
       expect_status_link 'research interview process', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'practice for interview' do
@@ -145,6 +174,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'practice for interview', 'no change'
       expect_status_link 'practice for interview', 'skip'
       expect_status_link 'practice for interview', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'attend interview' do
@@ -157,6 +188,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'attend interview', 'no change'
       expect_status_link 'attend interview', 'skip'
       expect_status_link 'attend interview', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'follow up after interview' do
@@ -170,6 +203,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'follow up after interview', 'skip'
       expect_status_link 'follow up after interview', 'fellow declined'
       expect_status_link 'follow up after interview', 'employer declined'
+      
+      skips_unsubscribed
     end
 
     describe 'receive offer' do
@@ -182,6 +217,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'receive offer', 'no change'
       expect_status_link 'receive offer', 'fellow declined'
       expect_status_link 'receive offer', 'employer declined'
+      
+      skips_unsubscribed
     end
 
     describe 'submit counter-offer' do
@@ -194,6 +231,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'submit counter-offer', 'no change'
       expect_status_link 'submit counter-offer', 'fellow accepted'
       expect_status_link 'submit counter-offer', 'fellow declined'
+      
+      skips_unsubscribed
     end
 
     describe 'accept offer' do
@@ -205,6 +244,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect_status_link 'accept offer', 'next'
       expect_status_link 'accept offer', 'no change'
       expect_status_link 'accept offer', 'fellow declined'
+      
+      skips_unsubscribed
     end
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe AccessToken, type: :model do
     
       it "has an array of routes" do
         expect(subject.routes).to be_an(Array)
-        expect(subject.routes.size).to eq(3)
+        expect(subject.routes.size).to eq(4)
       end
     
       it "generates access token with dashboard view only" do
@@ -192,6 +192,15 @@ RSpec.describe AccessToken, type: :model do
           controller: 'fellows',
           action: 'update',
           id: owner.id
+        }
+        
+        expect(subject.match?(request)).to be(true)
+      end
+      
+      it "generates a token with unsubscribe route" do
+        request = route_request 'GET', "http://localhost:3011/fellows/profile/unsubscribe", {
+          controller: 'fellow/profiles',
+          action: 'unsubscribe',
         }
         
         expect(subject.match?(request)).to be(true)

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -142,6 +142,22 @@ RSpec.describe Fellow, type: :model do
     end
   end
   
+  ########
+  # Scopes
+  ########
+
+  describe 'receive_opportunities' do
+    let(:subscribed) { create :fellow, receive_opportunities: true }
+    let(:unsubscribed) { create :fellow, receive_opportunities: false }
+    
+    before { subscribed; unsubscribed }
+    
+    subject { Fellow.receive_opportunities }
+    
+    it { should include(subscribed) }
+    it { should_not include(unsubscribed) }
+  end
+  
   ###############
   # Class methods
   ###############

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -404,4 +404,40 @@ RSpec.describe Fellow, type: :model do
     
     it { should eq(completed_positions) }
   end
+  
+  describe '#receive_opportunities!' do
+    it "sets unsubscribed fellow to subscribed" do
+      fellow = create :fellow, receive_opportunities: false
+      fellow.receive_opportunities!
+      
+      fellow.reload
+      expect(fellow.receive_opportunities).to eq(true)
+    end
+    
+    it "leaves subscribed fellow as subscribed" do
+      fellow = create :fellow, receive_opportunities: true
+      fellow.receive_opportunities!
+      
+      fellow.reload
+      expect(fellow.receive_opportunities).to eq(true)
+    end
+  end
+  
+  describe '#ignore_opportunities!' do
+    it "sets subscribed fellow to unsubscribed" do
+      fellow = create :fellow, receive_opportunities: true
+      fellow.ignore_opportunities!
+      
+      fellow.reload
+      expect(fellow.receive_opportunities).to eq(false)
+    end
+    
+    it "leaves unsubscribed fellow as unsubscribed" do
+      fellow = create :fellow, receive_opportunities: false
+      fellow.ignore_opportunities!
+      
+      fellow.reload
+      expect(fellow.receive_opportunities).to eq(false)
+    end
+  end
 end

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe Opportunity, type: :model do
       fellow.majors << major_child
     end
     
+    def unsubscribed
+      fellow.update receive_opportunities: false
+    end
+    
     describe 'with matching metro' do
       before { matching_metro }
     
@@ -175,6 +179,13 @@ RSpec.describe Opportunity, type: :model do
     
       it "excludes fellow when opp does not share the major" do
         fellow.majors << major_parent
+        expect(opportunity.candidates).to_not include(fellow)
+      end
+      
+      it "excludes fellow when unsubscribed from recieving opportunities" do
+        matching_industry
+        unsubscribed
+        
         expect(opportunity.candidates).to_not include(fellow)
       end
     end

--- a/spec/routing/fellow/profile_routing_spec.rb
+++ b/spec/routing/fellow/profile_routing_spec.rb
@@ -18,5 +18,9 @@ RSpec.describe Fellow::ProfilesController, type: :routing do
     it "routes to #update via PATCH" do
       expect(:patch => "/fellow/profile").to route_to("fellow/profiles#update")
     end
+
+    it "routes to #unsubscribe" do
+      expect(:get => "/fellow/profile/unsubscribe").to route_to("fellow/profiles#unsubscribe")
+    end
   end
 end


### PR DESCRIPTION
This turned out to be pretty involved. It required these steps: 

* add a boolean receives_opportunities flag on the fellow
* allow preference to be set in fellow's profile or admin view
* exclude unsubscribed fellows from opp candidate searches
* update mailer to check for subscription status before sending
* raise exception if future developers try to use direct mailer method without checking subscription
* add route for unsubscribing from opportunities
* add tokenized "unsubscribe" links to mailers

![20180904-specs](https://user-images.githubusercontent.com/12893/45057238-b7ae5180-b05a-11e8-8642-63be9f3c52bd.png)
