### PR TITLE
Add "How to Apply" to Opportunities

### DIFF
--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -105,13 +105,10 @@ class Admin::OpportunitiesController < ApplicationController
     params.require(:opportunity).permit(
       :_destroy,
       :name, :description, :employer_id, :job_posting_url, :application_deadline, 
-      :inbound, :recurring, :opportunity_type_id, :region_id,
+      :inbound, :recurring, :opportunity_type_id, :region_id, :how_to_apply,
       :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
-      industry_ids: [], 
-      interest_ids: [],
       steps: [],
-      metro_ids: [],
-      location_ids: [],
+      industry_ids: [], interest_ids: [], metro_ids: [], location_ids: [],
       locations_attributes: [
         :_destroy, :id, :name, :locateable_id, :locateable_type,
         contact_attributes: [:id, :address_1, :address_2, :city, :state, :postal_code, :phone, :email, :url]

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -42,6 +42,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :how_to_apply, 'How to Apply' %>
+    <%= form.text_area :how_to_apply %>
+  </div>
+
+  <div class="field">
     <%= form.label :job_posting_url %>
     <%= form.text_field :job_posting_url, required: true %>
   </div>

--- a/app/views/admin/opportunities/show.html.erb
+++ b/app/views/admin/opportunities/show.html.erb
@@ -15,6 +15,11 @@
   <strong>Description:</strong>
   <%= @opportunity.description %>
 </p>
+<p>
+  <strong>How to Apply:</strong>
+  <%= @opportunity.how_to_apply %>
+</p>
+
 
 <%= render 'admin/industries/list', object: @opportunity %>
 <%= render 'admin/interests/list', object: @opportunity %>

--- a/app/views/fellow/opportunities/show.html.erb
+++ b/app/views/fellow/opportunities/show.html.erb
@@ -4,6 +4,10 @@
   <%= @candidate.opportunity.description %>
 </p>
 <p>
+  <strong>How to Apply:</strong>
+  <%= @candidate.opportunity.how_to_apply %>
+</p>
+<p>
   <strong>Job Posting URL:</strong>
   <a href="<%= @candidate.opportunity.job_posting_url %>" target="_blank"><%= @candidate.opportunity.job_posting_url %></a>
 </p>

--- a/db/migrate/20180904210053_add_how_to_apply_to_opportunities.rb
+++ b/db/migrate/20180904210053_add_how_to_apply_to_opportunities.rb
@@ -1,0 +1,5 @@
+class AddHowToApplyToOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :how_to_apply, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_04_152137) do
+ActiveRecord::Schema.define(version: 2018_09_04_210053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -338,6 +338,7 @@ ActiveRecord::Schema.define(version: 2018_09_04_152137) do
     t.integer "opportunity_type_id"
     t.integer "region_id"
     t.boolean "published", default: false
+    t.text "how_to_apply"
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -168,6 +168,14 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
       
         expect(opportunity.locations).to include(location)
       end
+      
+      it "sets the 'how to apply' text" do
+        opportunity = create :opportunity
+        put :update, params: {id: opportunity.to_param, opportunity: new_attributes.merge(how_to_apply: 'Just Try It!')}, session: valid_session
+        opportunity.reload
+      
+        expect(opportunity.how_to_apply).to eq("Just Try It!")
+      end
     end
 
     context "with invalid params" do


### PR DESCRIPTION
This is relatively simple:

* add "how to apply" as a text field on opportunities
* allow opportunities to to be updated with new field
* show new field in admin/fellow views

![20180904b-specs](https://user-images.githubusercontent.com/12893/45058641-df9fb400-b05e-11e8-8567-44795d9c6c2c.png)
