### PR TITLE
Fix Token-based "Requested Link Unavailable" Glitch

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,13 +64,4 @@ class ApplicationController < ActionController::Base
       false
     end
   end
-  
-  def authorize_by_token!
-    fail_token_authorize! unless authorized_by_token?
-  end
-  
-  def fail_token_authorize!
-    flash[:notice] = 'The link you requested is unavailable.'
-    redirect_to root_path
-  end
 end

--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -1,5 +1,5 @@
 class CandidatesController < ApplicationController
-  before_action :authorize_by_token!
+  before_action :authenticate_user!
   
   def status
     if @fellow_opportunity = FellowOpportunity.find_by(id: params[:fellow_opportunity_id])

--- a/app/controllers/fellows_controller.rb
+++ b/app/controllers/fellows_controller.rb
@@ -1,5 +1,5 @@
 class FellowsController < ApplicationController
-  before_action :authorize_by_token!
+  before_action :authenticate_user!
   before_action :set_fellow
 
   def edit

--- a/config/opportunity_stage_content.yml
+++ b/config/opportunity_stage_content.yml
@@ -15,6 +15,9 @@ default notices: &default_notices
   fellow declined: "Thanks for letting us know."
   employer declined: "Sorry to hear that."
 
+respond to invitation:
+  notices: *default_notices
+    
 research employer:
   phase: "Apply"
   title: "Research this Employer"

--- a/spec/controllers/candidates_controller_spec.rb
+++ b/spec/controllers/candidates_controller_spec.rb
@@ -24,22 +24,19 @@ RSpec.describe CandidatesController, type: :controller do
     it "redirects without token" do
       get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted'}
 
-      expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to include('The link you requested is unavailable')
+      expect(response).to redirect_to(login_path)
     end
     
     it "redirects with bad token" do
       get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted', token: 'badtoken'}
 
-      expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to include('The link you requested is unavailable')
+      expect(response).to redirect_to(login_path)
     end
     
     it "redirects with bad fellow_opp id" do
       get :status, params: {fellow_opportunity_id: '1001', update: 'accepted', token: access_token.code}
       
-      expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to include('The link you requested is unavailable')
+      expect(response).to redirect_to(login_path)
     end
     
     it "returns http success" do

--- a/spec/controllers/fellows_controller_spec.rb
+++ b/spec/controllers/fellows_controller_spec.rb
@@ -31,11 +31,7 @@ RSpec.describe FellowsController, type: :controller do
       before { get :edit, params: {id: fellow.id} }
       
       it "redirects" do
-        expect(response).to redirect_to(root_path)
-      end
-      
-      it "sets flash notice" do
-        expect(flash[:notice]).to include('unavailable')
+        expect(response).to redirect_to(login_path)
       end
     end
     
@@ -50,11 +46,7 @@ RSpec.describe FellowsController, type: :controller do
       before { put :update, params: {id: fellow.id, fellow: {}} }
       
       it "redirects" do
-        expect(response).to redirect_to(root_path)
-      end
-      
-      it "sets flash notice" do
-        expect(flash[:notice]).to include('unavailable')
+        expect(response).to redirect_to(login_path)
       end
     end
 


### PR DESCRIPTION
**The problem:**

Following an e-mail link in response to an opportunity invitation sets the token for that opportunity in your session. Then, trying to update a different opportunity in a different window is a problem because that opp's token is no longer in the session - it's been overwritten by the most recent e-mail response to an opp.

**The soluion:**

The new order of operations is to try to authenticate by token first, if available, but fall back to whether you're currently logged in if the token is missing/bad. If you're not logged in, you'll be directed to do so, and then brought back to where you left off.

This gives the user the chance to login and then be able to work with any of their opps, regardless of what token might be stored in the system. 

![20180904c-specs](https://user-images.githubusercontent.com/12893/45061010-26de7280-b068-11e8-8767-b384410adcb5.png)
