### PR TITLE
Fixes for Daniel

### DIFF
--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -16,7 +16,7 @@ $(document).on "turbolinks:load",  ->
           autocomplete: {source: data}
           placeholder: placeholder
           delimiter: ";"
-          validationPattern: new RegExp('^[a-zA-Z0-9, \&/-]+$')
+          validationPattern: new RegExp('^[()a-zA-Z0-9, \&/-]+$')
           onAddTag: (tag) ->
             if $(tag).hasClass('auto-refresh')
               $(tag).form().submit()
@@ -63,7 +63,7 @@ $(document).on "turbolinks:load",  ->
           autocomplete: {source: data}
           placeholder: 'Add Industries/Interests/Majors'
           delimiter: ';'
-          validationPattern: new RegExp('^[a-zA-Z0-9, \&/-]+$')
+          validationPattern: new RegExp('^[()a-zA-Z0-9, \&/-]+$')
           onAddTag: (tag) ->
             if $(tag).hasClass('auto-refresh')
               $(tag).form().submit()

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -477,3 +477,7 @@ label.checkbox {
 form#opportunity-filters {
   margin-top: 2em;
 }
+
+td.numeric {
+  text-align: right;
+}

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -154,7 +154,7 @@ class Opportunity < ApplicationRecord
       [
         region.name,
         employer.name,
-        "=HYPERLINK(\"#{job_posting_url}\", \"#{name}\")",
+        name,
         opportunity_type.name,
         primary_city_state,
         job_posting_url,

--- a/app/views/admin/industries/index.html.erb
+++ b/app/views/admin/industries/index.html.erb
@@ -4,7 +4,8 @@
   <thead>
     <tr>
       <th>Name</th>
-      <th>Description</th>
+      <th>Opportunities</th>
+      <th>Fellows</th>
       <th colspan="2">Actions</th>
     </tr>
   </thead>
@@ -13,9 +14,14 @@
     <% @industries.each do |industry| %>
       <tr>
         <td><%= link_to industry.name, admin_industry_path(industry) %></td>
-        <td><%= industry.description %></td>
+        <td class="numeric"><%= industry.opportunities.count %></td>
+        <td class="numeric"><%= industry.fellows.count %></td>
         <td><%= link_to 'Edit', edit_admin_industry_path(industry), class: 'edit' %></td>
-        <td><%= link_to 'Delete', admin_industry_path(industry), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %></td>
+        <td>
+          <% if industry.opportunities.count + industry.fellows.count == 0 %>
+            <%= link_to 'Delete', admin_industry_path(industry), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/interests/index.html.erb
+++ b/app/views/admin/interests/index.html.erb
@@ -1,12 +1,26 @@
 <h1>Interests</h1>
 
 <table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Opportunities</th>
+      <th>Fellows</th>
+      <th colspan="2">Actions</th>
+    </tr>
+  </thead>
   <tbody>
     <% @interests.each do |interest| %>
       <tr>
         <td><%= link_to interest.name, admin_interest_path(interest) %></td>
+        <td class="numeric"><%= interest.opportunities.count %></td>
+        <td class="numeric"><%= interest.fellows.count %></td>
         <td><%= link_to 'Edit', edit_admin_interest_path(interest), class: 'edit' %></td>
-        <td><%= link_to 'Delete', admin_interest_path(interest), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %></td>
+        <td>
+          <% if interest.opportunities.count + interest.fellows.count == 0%>
+            <%= link_to 'Delete', admin_interest_path(interest), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Opportunity, type: :model do
     it { should be_an(Array) }
     it { expect(subject[0]).to eq(opportunity.region.name) }
     it { expect(subject[1]).to eq(opportunity.employer.name) }
-    it { expect(subject[2]).to eq('=HYPERLINK("http://example.com", "CSV Opp")') }
+    it { expect(subject[2]).to eq(opportunity.name) }
     it { expect(subject[3]).to eq(opportunity.opportunity_type.name) }
     it { expect(subject[4]).to eq('Omaha, NE') }
     it { expect(subject[5]).to eq(opportunity.job_posting_url) }


### PR DESCRIPTION
This is a set of small fixes that I lumped together into one PR:

* Statewide location tags were failing because we didn't allow parentheses in our list of approved tagging characters. This has been fixed.
* It was originally requested that the position name in the opps CSV export be hyperlinked to the job opportunity URL. Daniel has requested that we remove this after all.
* In order to safely allow management of industry/interest lists in MCM, staff can no longer delete industries/interests that are already in use by opps or fellows.

**screencap of industry/interest tag protection:** http://bit.ly/2osUDMx

![20180905-specs](https://user-images.githubusercontent.com/12893/45099436-e1b05400-b0ec-11e8-9b04-7713aae40b86.png)
