### PR TITLE
Real time metro tagging for zip codes

### DIFF
--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -104,7 +104,7 @@ $(document).on "turbolinks:load",  ->
         <option value=\"VT\">VT</option><option value=\"WA\">WA</option><option value=\"WI\">WI</option><option value=\"WV\">WV</option><option value=\"WY\">WY</option></select>
       </div>
 
-      <div class=\"field\"><label for=\"opportunity_locations_attributes_#{index}_contact_attributes_postal_code\">Postal code</label><input type=\"text\" name=\"opportunity[locations_attributes][#{index}][contact_attributes][postal_code]\" id=\"opportunity_locations_attributes_#{index}_contact_attributes_postal_code\" /></div>
+      <div class=\"field\"><label for=\"opportunity_locations_attributes_#{index}_contact_attributes_postal_code\">Postal code</label><input type=\"text\" name=\"opportunity[locations_attributes][#{index}][contact_attributes][postal_code]\" id=\"opportunity_locations_attributes_#{index}_contact_attributes_postal_code\" class=\"postal_code\"/></div>
       <div class=\"field\"><label for=\"opportunity_locations_attributes_#{index}_contact_attributes_phone\">Phone</label><input type=\"text\" name=\"opportunity[locations_attributes][#{index}][contact_attributes][phone]\" id=\"opportunity_locations_attributes_#{index}_contact_attributes_phone\" /></div>
       <div class=\"field\"><label for=\"opportunity_locations_attributes_#{index}_contact_attributes_email\">Email</label><input type=\"text\" name=\"opportunity[locations_attributes][#{index}][contact_attributes][email]\" id=\"opportunity_locations_attributes_#{index}_contact_attributes_email\" /></div>
       <div class=\"field\"><label for=\"opportunity_locations_attributes_#{index}_contact_attributes_url\">Url</label><input type=\"text\" name=\"opportunity[locations_attributes][#{index}][contact_attributes][url]\" id=\"opportunity_locations_attributes_#{index}_contact_attributes_url\" /></div>
@@ -119,6 +119,11 @@ $(document).on "turbolinks:load",  ->
     
       $(this).closest('.removeable_fields').find('.remove_hidden').attr('value', '1')
       $(this).closest('.removeable_fields').remove()
+    
+  reset_zip_match = () ->
+    $('input.postal_code').change (event) ->
+      $.get "/admin/metros/search?zip=#{event.target.value}", (data) ->
+        $("#opportunity_metro_tags").addTag(data['name'])
 
   $('a.new_location').click (event) ->
     event.preventDefault()
@@ -127,6 +132,7 @@ $(document).on "turbolinks:load",  ->
     
     reset_datepicker()
     reset_removeable()
+    reset_zip_match()
 
   $('.toggle-next').click (e) ->
     e.preventDefault();
@@ -135,3 +141,4 @@ $(document).on "turbolinks:load",  ->
 
   reset_datepicker()
   reset_removeable()
+  reset_zip_match()

--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -112,7 +112,7 @@ $(document).on "turbolinks:load",  ->
 
   add_metro_tag = (zip) ->
       $.get "/admin/metros/search?zip=#{zip}", (data) ->
-        $("#opportunity_metro_tags").addTag(data['name'])
+        $(".metro-tags").addTag(data['name'])
     
   reset_datepicker = () ->
     $('.datetime').datepicker({dateFormat: 'yy-mm-dd'})

--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -110,6 +110,10 @@ $(document).on "turbolinks:load",  ->
       <div class=\"field\"><label for=\"opportunity_locations_attributes_#{index}_contact_attributes_url\">Url</label><input type=\"text\" name=\"opportunity[locations_attributes][#{index}][contact_attributes][url]\" id=\"opportunity_locations_attributes_#{index}_contact_attributes_url\" /></div>
     </li>"
 
+  add_metro_tag = (zip) ->
+      $.get "/admin/metros/search?zip=#{zip}", (data) ->
+        $("#opportunity_metro_tags").addTag(data['name'])
+    
   reset_datepicker = () ->
     $('.datetime').datepicker({dateFormat: 'yy-mm-dd'})
     
@@ -122,8 +126,11 @@ $(document).on "turbolinks:load",  ->
     
   reset_zip_match = () ->
     $('input.postal_code').change (event) ->
-      $.get "/admin/metros/search?zip=#{event.target.value}", (data) ->
-        $("#opportunity_metro_tags").addTag(data['name'])
+      add_metro_tag(this.value)
+      
+    $('input.location[type="checkbox"]').change (event) ->
+      if (this.checked)
+        add_metro_tag($(this).data('zip'))
 
   $('a.new_location').click (event) ->
     event.preventDefault()

--- a/app/controllers/admin/metros_controller.rb
+++ b/app/controllers/admin/metros_controller.rb
@@ -11,4 +11,16 @@ class Admin::MetrosController < ApplicationController
     @metros = Metro.order('name asc').all
     render layout: false
   end
+  
+  def search
+    respond_to do |format|
+      format.json do
+        if postal_code = PostalCode.find_by(code: params[:zip])
+          render json: postal_code.metro.as_json 
+        else
+          render json: nil
+        end
+      end
+    end
+  end
 end

--- a/app/controllers/admin/metros_controller.rb
+++ b/app/controllers/admin/metros_controller.rb
@@ -1,6 +1,6 @@
 class Admin::MetrosController < ApplicationController
-  before_action :authenticate_user!, except: [:list]
-  before_action :ensure_admin!, except: [:list]
+  before_action :authenticate_user!, except: [:list, :search]
+  before_action :ensure_admin!, except: [:list, :search]
 
   # GET /metros.json
   def index

--- a/app/models/postal_code.rb
+++ b/app/models/postal_code.rb
@@ -77,6 +77,6 @@ class PostalCode < ApplicationRecord
   
   def metro
     return @metro if defined?(@metro)
-    @metro = Metro.find_by code: msa_code
+    @metro = Metro.find_by(code: msa_code) || Metro.find_by(code: state)
   end
 end

--- a/app/models/postal_code.rb
+++ b/app/models/postal_code.rb
@@ -74,4 +74,9 @@ class PostalCode < ApplicationRecord
   def lon= new_longitude
     self.longitude = new_longitude
   end
+  
+  def metro
+    return @metro if defined?(@metro)
+    @metro = Metro.find_by code: msa_code
+  end
 end

--- a/app/views/admin/contacts/_nested_form.html.erb
+++ b/app/views/admin/contacts/_nested_form.html.erb
@@ -21,7 +21,7 @@
   
   <div class="field">
     <%= contact_form.label :postal_code %>
-    <%= contact_form.text_field :postal_code %>
+    <%= contact_form.text_field :postal_code, class: 'postal_code' %>
   </div>
   
   <div class="field">

--- a/app/views/admin/fellows/_form.html.erb
+++ b/app/views/admin/fellows/_form.html.erb
@@ -96,7 +96,7 @@
     <%= link_to 'full list', list_admin_metros_path, target: '_blank' %>
 
     <div id="metro-tags" class="jquery-tags">
-      <%= form.text_area :metro_tags %>
+      <%= form.text_area :metro_tags, class: 'metro-tags' %>
     </div>
   </div>
 

--- a/app/views/admin/locations/_check_boxes.html.erb
+++ b/app/views/admin/locations/_check_boxes.html.erb
@@ -5,7 +5,7 @@
   <% parent.locations.order('name asc').each do |location| %>
     <% tag_id = "location_ids_#{location.id}" %>
     
-    <%= check_box_tag("#{object_name}[location_ids][]", location.id, object.locations.include?(location), id: tag_id) %>
+    <%= check_box_tag("#{object_name}[location_ids][]", location.id, object.locations.include?(location), id: tag_id, 'data-zip' => location.contact.postal_code, class: 'location') %>
     <%= label_tag(tag_id, location.label, style: 'display: inline;') %><br>
   <% end %>
 </div>

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -147,7 +147,7 @@
     <%= link_to 'full list', list_admin_metros_path, target: '_blank' %>
   
     <div id="metro-tags" class="jquery-tags">
-      <%= form.text_area :metro_tags %>
+      <%= form.text_area :metro_tags, class: 'metro-tags' %>
     </div>
   </div>
 

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -96,7 +96,7 @@
 
           <div class="field">
             <%= contact_form.label :postal_code %>
-            <%= contact_form.text_field :postal_code %>
+            <%= contact_form.text_field :postal_code, class: 'postal_code' %>
           </div>
 
           <div class="field">

--- a/app/views/fellow/profiles/_form.html.erb
+++ b/app/views/fellow/profiles/_form.html.erb
@@ -81,7 +81,7 @@
   <%= link_to 'full metro areas list', list_admin_metros_path, target: '_blank' %>
 
   <div id="metro-tags" class="jquery-tags">
-    <%= form.text_area :metro_tags %>
+    <%= form.text_area :metro_tags, class: 'metro-tags' %>
   </div>
 
   <div class="actions">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
     resources :metros, only: [:index] do
       collection do
         get :list
+        get :search
       end
     end
     resources :cohort_fellows

--- a/db/migrate/20180905181746_add_city_state_to_postal_codes.rb
+++ b/db/migrate/20180905181746_add_city_state_to_postal_codes.rb
@@ -1,0 +1,7 @@
+class AddCityStateToPostalCodes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :postal_codes, :city, :string
+    add_column :postal_codes, :state, :string
+    add_index :postal_codes, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_04_210053) do
+ActiveRecord::Schema.define(version: 2018_09_06_125011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,27 @@ ActiveRecord::Schema.define(version: 2018_09_04_210053) do
     t.datetime "expires_at"
     t.index ["code"], name: "index_access_tokens_on_code", unique: true
     t.index ["owner_id", "owner_type"], name: "index_access_tokens_on_owner_id_and_owner_type"
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
   create_table "candidate_logs", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -376,7 +376,10 @@ ActiveRecord::Schema.define(version: 2018_09_04_210053) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "msa_code"
+    t.string "city"
+    t.string "state"
     t.index ["code"], name: "index_postal_codes_on_code"
+    t.index ["state"], name: "index_postal_codes_on_state"
   end
 
   create_table "regions", force: :cascade do |t|

--- a/lib/tasks/postal.rake
+++ b/lib/tasks/postal.rake
@@ -1,3 +1,5 @@
+require 'csv'
+
 namespace :postal do
   def load_postal_codes
     PostalCode.load_csv("#{Rails.root}/tmp/postal-codes.csv")
@@ -17,6 +19,23 @@ namespace :postal do
   desc "load metro areas from tmp/msa.txt"
   task metros: :environment do
     load_metros
+  end
+  
+  desc "add states to postal code records"
+  task states: :environment do
+    codes = Hash.new{|h,k| h[k] = Array.new}
+    
+    puts "Loading state zip codes from file"
+    CSV.foreach('tmp/postal-codes.csv', headers: true) do |row|
+      codes[row['StateAbbr']] << row['ZIPCode']
+    end
+    
+    codes.each do |state, zips|
+      PostalCode.where(code: zips.uniq).update_all(state: state)
+      print '.'; $stdout.flush
+    end
+    
+    puts
   end
   
   desc "load both postal codes and metros from tmp directory"

--- a/spec/controllers/admin/metros_controller_spec.rb
+++ b/spec/controllers/admin/metros_controller_spec.rb
@@ -76,4 +76,55 @@ RSpec.describe Admin::MetrosController, type: :controller do
       expect(response).to be_successful
     end
   end
+  
+  describe 'GET #search' do
+    let(:postal_code) { create :postal_code, msa_code: '1001' }
+    let(:metro) { create :metro, code: postal_code.msa_code }
+    
+    describe 'when metro is found' do
+      before { postal_code; metro }
+    
+      it "returns a success response" do
+        get :search, params: {zip: postal_code.code, format: 'json'}, session: valid_session
+        expect(response).to be_successful
+      end
+      
+      it "returns the metro" do
+        get :search, params: {zip: postal_code.code, format: 'json'}, session: valid_session
+        
+        json = JSON.parse(response.body)
+        expect(json['name']).to eq(metro.name)
+      end
+    end
+
+    describe 'when metro is NOT found' do
+      before { postal_code }
+      
+      it "returns a success response" do
+        get :search, params: {zip: postal_code.code, format: 'json'}, session: valid_session
+        expect(response).to be_successful
+      end
+      
+      it "returns the metro" do
+        get :search, params: {zip: postal_code.code, format: 'json'}, session: valid_session
+        
+        json = JSON.parse(response.body)
+        expect(json).to be_nil
+      end
+    end
+
+    describe 'when postal_code is NOT found' do
+      it "returns a success response" do
+        get :search, params: {zip: '00000', format: 'json'}, session: valid_session
+        expect(response).to be_successful
+      end
+      
+      it "returns the metro" do
+        get :search, params: {zip: '00000', format: 'json'}, session: valid_session
+        
+        json = JSON.parse(response.body)
+        expect(json).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/postal_code_spec.rb
+++ b/spec/models/postal_code_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe PostalCode, type: :model do
   end
   
   describe '#metro' do
-    let(:postal_code) { create :postal_code, msa_code: '0000' }
+    let(:postal_code) { create :postal_code, msa_code: '0000', state: 'NE' }
+    let(:state) { create :metro, code: state_code, name: 'Nebraska (Statewide)' }
     let(:metro) { create :metro, code: metro_code }
     
     subject { postal_code.metro }
@@ -120,6 +121,7 @@ RSpec.describe PostalCode, type: :model do
     
     describe 'when postal code maps to an existing metro' do
       let(:metro_code) { postal_code.msa_code }
+      let(:state_code) { postal_code.state }
 
       it { should eq(metro) }
       
@@ -129,13 +131,30 @@ RSpec.describe PostalCode, type: :model do
       end
     end
     
-    describe 'when postal code does NOT map to an existing metro' do
+    describe 'when postal code does NOT map to an existing metro, but state exists' do
       let(:metro_code) { '1111' }
+      let(:state_code) { postal_code.state }
+
+      it { should eq(state) }
+      
+      it "memoizes the result" do
+        expect(Metro).to receive(:find_by).with(code: postal_code.msa_code).once.and_return(nil)
+        expect(Metro).to receive(:find_by).with(code: postal_code.state).once.and_return(nil)
+
+        2.times { postal_code.metro }
+      end
+    end
+    
+    describe 'when postal code does NOT map to an existing metro, and state does NOT exist' do
+      let(:metro_code) { '1111' }
+      let(:state_code) { 'NA' }
 
       it { should be_nil }
       
       it "memoizes the result" do
         expect(Metro).to receive(:find_by).with(code: postal_code.msa_code).once.and_return(nil)
+        expect(Metro).to receive(:find_by).with(code: postal_code.state).once.and_return(nil)
+
         2.times { postal_code.metro }
       end
     end

--- a/spec/models/postal_code_spec.rb
+++ b/spec/models/postal_code_spec.rb
@@ -109,4 +109,35 @@ RSpec.describe PostalCode, type: :model do
       expect(postal_code.longitude).to eq(-100.0)
     end
   end
+  
+  describe '#metro' do
+    let(:postal_code) { create :postal_code, msa_code: '0000' }
+    let(:metro) { create :metro, code: metro_code }
+    
+    subject { postal_code.metro }
+    
+    before { postal_code; metro }
+    
+    describe 'when postal code maps to an existing metro' do
+      let(:metro_code) { postal_code.msa_code }
+
+      it { should eq(metro) }
+      
+      it "memoizes the result" do
+        expect(Metro).to receive(:find_by).with(code: postal_code.msa_code).once.and_return(metro)
+        2.times { postal_code.metro }
+      end
+    end
+    
+    describe 'when postal code does NOT map to an existing metro' do
+      let(:metro_code) { '1111' }
+
+      it { should be_nil }
+      
+      it "memoizes the result" do
+        expect(Metro).to receive(:find_by).with(code: postal_code.msa_code).once.and_return(nil)
+        2.times { postal_code.metro }
+      end
+    end
+  end
 end

--- a/spec/routing/admin/metros_routing_spec.rb
+++ b/spec/routing/admin/metros_routing_spec.rb
@@ -9,5 +9,9 @@ RSpec.describe Admin::MetrosController, type: :routing do
     it "routes to #list" do
       expect(:get => "/admin/metros/list").to route_to("admin/metros#list")
     end
+
+    it "routes to #search" do
+      expect(:get => "/admin/metros/search").to route_to("admin/metros#search")
+    end
   end
 end


### PR DESCRIPTION
To prevent staff from having to enter a location for an opp, and then ALSO having to add that location's metro tag, we're automagically adding the correct metro tag in real time when a location is specified. This works whether location is specified by adding a new location from scratch, or selecting an existing location from the available checkboxes.  This happens in three places:

* when admin manages an opp
* when admin manages a fellow (they also have location and metro tags)
* when a fellow manages their own profile

We were already doing this on the backend - if no metro tags were selected, we'd auto-add one when the opp was created. But staff wouldn't know this, so it wasn't saving them effort. It was just helping preserve data integrity. Now it's helping streamline the staff's process as well.

**UPDATE:** in the absence of a metro tag (for zip codes that don't map to a metro area, like western Nebraska), the corresponding "statewide" tag will be used.

**screencap:** http://bit.ly/2MQl65m

![20180905b](https://user-images.githubusercontent.com/12893/45109208-72465e80-b104-11e8-9c9f-6c59a5b013c0.png)
