### PR TITLE
Update Industries/Interests Lists

### DIFF
--- a/config/industries.yml
+++ b/config/industries.yml
@@ -1,0 +1,45 @@
+- Accounting
+- Advertising
+- Aerospace
+- Agriculture
+- Architecture & Planning
+- Banking & Finance
+- Beauty & Cosmetics
+- Biotechnology
+- Business
+- Chemical & Physical Science
+- Communications & Public Relations
+- Computer Engineering
+- Computer Hardware
+- Consulting
+- Consumer Goods
+- Education
+- Energy
+- Environment
+- Fashion
+- Film
+- Food & Beverage
+- Health
+- Higher Education
+- Hospitality
+- Information Technology
+- Insurance
+- International Affairs
+- Journalism
+- Law
+- Law Enforcement
+- Manufacturing
+- Marketing & Advertising
+- Non-profit
+- Performing Arts
+- Pharmaceutical
+- Politics
+- Psychology & Counseling
+- Public Administration
+- Publishing
+- Real Estate
+- Sports
+- Technology
+- Telecommunications
+- Tourism
+- Transportation

--- a/config/interests.yml
+++ b/config/interests.yml
@@ -1,0 +1,16 @@
+- Arts and Design
+- Business Development
+- Community & Social Services
+- Engineering
+- Entrepreneurship
+- Human Resources
+- Military & Protective Services
+- Operations
+- Product Management
+- Program Managment
+- Project Management
+- Purchasing
+- Quality Assurance
+- Research
+- Sales
+- Writing

--- a/db/migrate/20180905195348_update_industry_interest_lists.rb
+++ b/db/migrate/20180905195348_update_industry_interest_lists.rb
@@ -1,0 +1,29 @@
+require 'yaml'
+
+class UpdateIndustryInterestLists < ActiveRecord::Migration[5.2]
+  def up
+    # industries
+    names = YAML.load(File.read("#{Rails.root}/config/industries.yml"))
+    
+    # remove those not on this new list
+    Industry.where.not(name: names).destroy_all
+    
+    names.each do |name|
+      Industry.find_or_create_by name: name
+    end
+    
+    # interests
+    names = YAML.load(File.read("#{Rails.root}/config/interests.yml"))
+    
+    # remove those not on this new list
+    Interest.where.not(name: names).destroy_all
+    
+    names.each do |name|
+      Interest.find_or_create_by name: name
+    end
+  end
+  
+  def down
+    puts "Not reversible, but not the end of the world, either."
+  end
+end


### PR DESCRIPTION
Daniel requested that we use the newly curated lists of industries and interests that he and Lucy put together. I wanted to do it with the least amount of interruption to existing opps/fellows and their industry/interest tags, so here's the process I used for each data set (industries and interests):

* load the new list
* remove db records that are not on the new list
* add db records that are on the new list, but not yet in the db

This preserved the items that were on both the old and the new lists, so that opps and fellows who were already tagged with them will still be tagged with them. Sadly, there may be tags which are similar but not exactly the same, and those tags will be lost until they're recreated. Luckily, we're pre-launch.

![20180905c-specs](https://user-images.githubusercontent.com/12893/45118446-286a7200-b11e-11e8-8bec-84b8e52745f0.png)
