### PR TITLE
Mark Opportunities as "Unpublished"

### DIFF
--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -2,7 +2,7 @@ class Admin::OpportunitiesController < ApplicationController
   before_action :authenticate_user!
   before_action :ensure_admin!
   before_action :set_employer
-  before_action :set_opportunity, only: [:show, :edit, :update, :destroy]
+  before_action :set_opportunity, only: [:show, :edit, :update, :unpublish, :destroy]
 
   # GET /opportunities
   # GET /opportunities.json
@@ -66,6 +66,11 @@ class Admin::OpportunitiesController < ApplicationController
         format.json { render json: @opportunity.errors, status: :unprocessable_entity }
       end
     end
+  end
+  
+  def unpublish
+    @opportunity.unpublish!
+    redirect_to request.referer
   end
 
   # DELETE /opportunities/1

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -207,6 +207,10 @@ class Opportunity < ApplicationRecord
     end
   end
   
+  def unpublish!
+    update published: false
+  end
+  
   private
   
   def archived_fellow_opp candidate_id

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -14,20 +14,21 @@
           <th>Employer</th>
           <th>Title</th>
           <th>Description</th>
-          <th colspan="2">Actions</th>
+          <th colspan="3">Actions</th>
           <th>Export</th>
         </tr>
       </thead>
 
       <tbody>
-        <% opportunities.each do |opportunity| %>
+        <% opportunities.sort_by{|o| [o.employer.name, o.name]}.each do |opportunity| %>
           <tr>
             <td><%= opportunity.employer.name %>
             <td><%= link_to opportunity.name, admin_opportunity_path(opportunity) %></td>
             <td><%= truncate(opportunity.description, length: 100, separator: ' ') %></td>
             <td><%= link_to 'Edit', edit_admin_opportunity_path(opportunity), class: 'edit' %></td>
             <td><%= link_to 'Delete', admin_opportunity_path(opportunity), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %></td>
-            <td><%= check_box_tag 'export_ids[]', opportunity.id, !opportunity.published %></td>
+            <td><%= link_to('Unpublish', unpublish_admin_opportunity_path(opportunity), method: :put, class: 'edit') if opportunity.published? %></td>
+            <td class="numeric"><%= check_box_tag 'export_ids[]', opportunity.id, !opportunity.published %></td>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,10 @@ Rails.application.routes.draw do
       collection do
         post :export
       end
+      
+      member do
+        put :unpublish
+      end
     end
 
     resources :sites, shallow: true do

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -179,6 +179,26 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
     end
   end
 
+  describe "PUT #unpublish" do
+    let(:referer) { '/admin/opportunities' }
+    
+    before { request.env['HTTP_REFERER'] = referer }
+
+    it "unpublishes the opportunity" do
+      opportunity = create :opportunity, published: true
+      put :unpublish, params: {id: opportunity.to_param}, session: valid_session
+      
+      expect(opportunity.reload.published).to eq(false)
+    end
+    
+    it "redirects to the referring page" do
+      opportunity = create :opportunity, published: true
+      put :unpublish, params: {id: opportunity.to_param}, session: valid_session
+      
+      expect(response).to redirect_to(referer)
+    end
+  end
+
   describe "DELETE #destroy" do
     it "destroys the requested opportunity" do
       opportunity = create :opportunity

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -363,4 +363,18 @@ RSpec.describe Opportunity, type: :model do
       it { should eq(6) }
     end
   end
+  
+  describe '#unpublish!' do
+    subject { opportunity.unpublish!; opportunity.reload.published }
+    
+    describe 'when opp is already published' do
+      let(:opportunity) { create :opportunity, published: true }
+      it { should eq(false) }
+    end
+
+    describe 'when opp is unpublished' do
+      let(:opportunity) { create :opportunity, published: false }
+      it { should eq(false) }
+    end
+  end
 end

--- a/spec/routing/admin/opportunities_routing_spec.rb
+++ b/spec/routing/admin/opportunities_routing_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Admin::OpportunitiesController, type: :routing do
       expect(:put => "/admin/opportunities/1").to route_to("admin/opportunities#update", :id => "1")
     end
 
+    it "routes to #unpublish via PUT" do
+      expect(:put => "/admin/opportunities/1/unpublish").to route_to("admin/opportunities#unpublish", :id => "1")
+    end
+
     it "routes to #update via PATCH" do
       expect(:patch => "/admin/opportunities/1").to route_to("admin/opportunities#update", :id => "1")
     end


### PR DESCRIPTION
When opps are exported to CSV, we mark them as "published" so that it's easier to select unpublished opps the next time an export is performed. But there wasn't a way for staff to "unpublish" an opp that was exported, but never used. Opportunity listings now have an "unpublish" if they have been previously published, to restore them to this pristine state :)

**screencap:** http://bit.ly/2NOlYE0

![20180905d-specs](https://user-images.githubusercontent.com/12893/45120354-733ab880-b123-11e8-8bbc-aa6659765d93.png)
