### PR TITLE
Improve Opportunity Sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ spec.log
 /tmp/
 /config/deploy/production.rb
 /config/deploy/staging.rb
+/storage
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -89,7 +89,7 @@ class Admin::OpportunitiesController < ApplicationController
   
   def set_employer
     @employer = Employer.find(params[:employer_id]) if params[:employer_id]
-    @opportunities = (@employer ? @employer.opportunities : Opportunity).paginate(page: params[:page])
+    @opportunities = (@employer ? @employer.opportunities : Opportunity).prioritized.paginate(page: params[:page])
     
     unless params[:region_id].blank?
       @opportunities = @opportunities.where(region_id: params[:region_id])
@@ -97,7 +97,7 @@ class Admin::OpportunitiesController < ApplicationController
   end
   
   def unpaginated_opportunities
-    (@employer ? @employer.opportunities : Opportunity).where(id: params[:export_ids]).sort_by(&:priority).sort_by{|o| o.region.position}
+    (@employer ? @employer.opportunities : Opportunity).where(id: params[:export_ids]).prioritized.sort_by{|o| o.region.position}
   end
   
   # Use callbacks to share common setup or constraints between actions.

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -24,6 +24,8 @@ class Opportunity < ApplicationRecord
   validates :job_posting_url, url: {ensure_protocol: true}
   validate :validate_locateable
   
+  scope :prioritized, -> { order(priority: :asc) }
+  
   before_save :set_priority
   
   class << self

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -190,7 +190,7 @@ class Opportunity < ApplicationRecord
   def priority
     employer_partner = employer.employer_partner
     
-    if employer_partner && inbound && recurring
+    value = if employer_partner && inbound && recurring
       0
     elsif employer_partner && inbound
       1
@@ -205,6 +205,10 @@ class Opportunity < ApplicationRecord
     else
       6
     end
+    
+    value += 10 if published?
+    
+    value
   end
   
   def unpublish!

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -187,7 +187,7 @@ class Opportunity < ApplicationRecord
   end
   
   # lowest priority is best/first
-  def priority
+  def calculated_priority
     employer_partner = employer.employer_partner
     
     value = if employer_partner && inbound && recurring

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -24,6 +24,8 @@ class Opportunity < ApplicationRecord
   validates :job_posting_url, url: {ensure_protocol: true}
   validate :validate_locateable
   
+  before_save :set_priority
+  
   class << self
     def csv_headers
       ['Region', 'Employer', 'Position', 'Type', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
@@ -244,5 +246,9 @@ class Opportunity < ApplicationRecord
   
   def has_postal_code?
     !postal_codes.empty?
+  end
+  
+  def set_priority
+    self.priority = calculated_priority
   end
 end

--- a/app/views/admin/employers/index.html.erb
+++ b/app/views/admin/employers/index.html.erb
@@ -2,7 +2,7 @@
 
 <table class="action-list employers">
   <tbody>
-    <% @employers.each do |employer| %>
+    <% @employers.order(name: :asc).each do |employer| %>
       <tr>
         <td><%= link_to employer.name, admin_employer_path(employer) %></td>
         <td><%= link_to 'Edit', edit_admin_employer_path(employer), class: 'edit' %></td>

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -20,7 +20,7 @@
       </thead>
 
       <tbody>
-        <% opportunities.sort_by{|o| [o.employer.name, o.name]}.each do |opportunity| %>
+        <% opportunities.each do |opportunity| %>
           <tr>
             <td><%= opportunity.employer.name %>
             <td><%= link_to opportunity.name, admin_opportunity_path(opportunity) %></td>

--- a/db/migrate/20180906194400_add_priority_to_opportunities.rb
+++ b/db/migrate/20180906194400_add_priority_to_opportunities.rb
@@ -1,6 +1,6 @@
 class AddPriorityToOpportunities < ActiveRecord::Migration[5.2]
   def change
-    add_column :opportunities, :priority, :integer
+    add_column :opportunities, :priority, :integer, default: 1000
     add_index :opportunities, :priority
   end
 end

--- a/db/migrate/20180906194400_add_priority_to_opportunities.rb
+++ b/db/migrate/20180906194400_add_priority_to_opportunities.rb
@@ -1,0 +1,6 @@
+class AddPriorityToOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :priority, :integer
+    add_index :opportunities, :priority
+  end
+end

--- a/db/migrate/20180906203137_update_priority_for_all_opportunities.rb
+++ b/db/migrate/20180906203137_update_priority_for_all_opportunities.rb
@@ -1,0 +1,8 @@
+class UpdatePriorityForAllOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    Opportunity.all.each do |opp|
+      opp.send(:set_priority)
+      opp.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_06_194400) do
+ActiveRecord::Schema.define(version: 2018_09_06_203137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -360,7 +360,7 @@ ActiveRecord::Schema.define(version: 2018_09_06_194400) do
     t.integer "region_id"
     t.boolean "published", default: false
     t.text "how_to_apply"
-    t.integer "priority"
+    t.integer "priority", default: 1000
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_06_125011) do
+ActiveRecord::Schema.define(version: 2018_09_06_194400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -360,9 +360,11 @@ ActiveRecord::Schema.define(version: 2018_09_06_125011) do
     t.integer "region_id"
     t.boolean "published", default: false
     t.text "how_to_apply"
+    t.integer "priority"
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"
+    t.index ["priority"], name: "index_opportunities_on_priority"
     t.index ["published"], name: "index_opportunities_on_published"
     t.index ["recurring"], name: "index_opportunities_on_recurring"
     t.index ["region_id"], name: "index_opportunities_on_region_id"

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -66,6 +66,19 @@ RSpec.describe Opportunity, type: :model do
     end
   end
   
+  ###########
+  # Callbacks
+  ###########
+
+  it "sets the priority before save" do
+    opportunity = build :opportunity
+    allow(opportunity).to receive(:calculated_priority).and_return(42)
+    expect(opportunity.priority).to be_nil
+    
+    opportunity.save
+    expect(opportunity.priority).to eq(42)
+  end
+  
   ###############
   # Serialization
   ###############

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -73,10 +73,33 @@ RSpec.describe Opportunity, type: :model do
   it "sets the priority before save" do
     opportunity = build :opportunity
     allow(opportunity).to receive(:calculated_priority).and_return(42)
-    expect(opportunity.priority).to be_nil
+    expect(opportunity.priority).to eq(Opportunity.column_defaults['priority'])
     
     opportunity.save
     expect(opportunity.priority).to eq(42)
+  end
+  
+  ########
+  # Scopes
+  ########
+
+  describe 'prioritized' do
+    let(:partner) { create :employer, employer_partner: true }
+    let(:nonpartner) { create :employer, employer_partner: false }
+    
+    let(:first)  { create :opportunity, published: false, employer: partner,    inbound: true,  recurring: true }
+    let(:second) { create :opportunity, published: false, employer: nonpartner, inbound: false, recurring: false }
+    let(:third)  { create :opportunity, published: true,  employer: partner,    inbound: true,  recurring: true }
+    let(:fourth) { create :opportunity, published: true,  employer: nonpartner, inbound: false, recurring: false }
+    
+    before { second; fourth; first; third }
+    
+    subject { Opportunity.prioritized }
+    
+    it { expect(subject[0]).to eq(first) }
+    it { expect(subject[1]).to eq(second) }
+    it { expect(subject[2]).to eq(third) }
+    it { expect(subject[3]).to eq(fourth) }
   end
   
   ###############

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -329,7 +329,7 @@ RSpec.describe Opportunity, type: :model do
     let(:inbound) { false }
     let(:recurring) { false }
     
-    subject { opportunity.priority }
+    subject { opportunity.calculated_priority }
     
     describe 'when previously published' do
       let(:published) { true }

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -323,55 +323,104 @@ RSpec.describe Opportunity, type: :model do
   
   describe '#priority' do
     let(:employer) { create :employer, employer_partner: employer_partner }
-    let(:opportunity) { build :opportunity, employer: employer, inbound: inbound, recurring: recurring }
+    let(:opportunity) { build :opportunity, employer: employer, inbound: inbound, recurring: recurring, published: published }
 
     let(:employer_partner) { false }
     let(:inbound) { false }
     let(:recurring) { false }
     
-    
     subject { opportunity.priority }
     
-    describe 'when employer_partner AND inbound AND recurring' do
-      let(:employer_partner) { true }
-      let(:inbound) { true }
-      let(:recurring) { true }
+    describe 'when previously published' do
+      let(:published) { true }
       
-      it { should eq(0) }
-    end
+      describe 'when employer_partner AND inbound AND recurring' do
+        let(:employer_partner) { true }
+        let(:inbound) { true }
+        let(:recurring) { true }
+      
+        it { should eq(10) }
+      end
     
-    describe 'when employer_partner AND inbound' do
-      let(:employer_partner) { true }
-      let(:inbound) { true }
+      describe 'when employer_partner AND inbound' do
+        let(:employer_partner) { true }
+        let(:inbound) { true }
 
-      it { should eq(1) }
-    end
+        it { should eq(11) }
+      end
     
-    describe 'when inbound' do
-      let(:inbound) { true }
-      it { should eq(2) }
-    end
+      describe 'when inbound' do
+        let(:inbound) { true }
+        it { should eq(12) }
+      end
     
-    describe 'when employer_partner AND recurring' do
-      let(:employer_partner) { true }
-      let(:recurring) { true }
+      describe 'when employer_partner AND recurring' do
+        let(:employer_partner) { true }
+        let(:recurring) { true }
       
-      it { should eq(3) }
-    end
+        it { should eq(13) }
+      end
     
-    describe 'when employer_partner' do
-      let(:employer_partner) { true }
+      describe 'when employer_partner' do
+        let(:employer_partner) { true }
       
-      it { should eq(4) }
+        it { should eq(14) }
+      end
+    
+      describe 'when recurring' do
+        let(:recurring) { true }
+        it { should eq(15) }
+      end
+    
+      describe 'when none are true' do
+        it { should eq(16) }
+      end
     end
     
-    describe 'when recurring' do
-      let(:recurring) { true }
-      it { should eq(5) }
-    end
+    describe 'when not previously published' do
+      let(:published) { false }
+      
+      describe 'when employer_partner AND inbound AND recurring' do
+        let(:employer_partner) { true }
+        let(:inbound) { true }
+        let(:recurring) { true }
+      
+        it { should eq(0) }
+      end
     
-    describe 'when none are true' do
-      it { should eq(6) }
+      describe 'when employer_partner AND inbound' do
+        let(:employer_partner) { true }
+        let(:inbound) { true }
+
+        it { should eq(1) }
+      end
+    
+      describe 'when inbound' do
+        let(:inbound) { true }
+        it { should eq(2) }
+      end
+    
+      describe 'when employer_partner AND recurring' do
+        let(:employer_partner) { true }
+        let(:recurring) { true }
+      
+        it { should eq(3) }
+      end
+    
+      describe 'when employer_partner' do
+        let(:employer_partner) { true }
+      
+        it { should eq(4) }
+      end
+    
+      describe 'when recurring' do
+        let(:recurring) { true }
+        it { should eq(5) }
+      end
+    
+      describe 'when none are true' do
+        it { should eq(6) }
+      end
     end
   end
   


### PR DESCRIPTION
We've been sorting the opportunity CSV exports by "priority" which is a list of rules governing what's more important in selecting an opp for inclusion in the Braven Opportunities Newsletter. This PR makes two critical changes:

* unpublished opps now get top priority - before, published status was not a factor at all.
* opportunities are sorted on the website by priority, in the same way they would appear in the CSV.
* priority is now saved as a column on the opps table, so that sorting can be done at the database level. This was necessary to preserve pagination, and for optimal sorting.

These changes will help regional staff quickly find the most relevant opps to include in the newsletters.

**screencap:** http://bit.ly/2MQlyAu

![20180906b-specs](https://user-images.githubusercontent.com/12893/45185064-8cf50200-b1ee-11e8-8113-41d7957637a0.png)
