### PR TITLE
Track fellow job type preferences

### DIFF
--- a/app/controllers/admin/fellows_controller.rb
+++ b/app/controllers/admin/fellows_controller.rb
@@ -96,7 +96,7 @@ class Admin::FellowsController < ApplicationController
         :interests_description, :major, :affiliations, :gpa, :linkedin_url, :staff_notes, :efficacy_score, 
         :employment_status_id, :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
         :resume, :receive_opportunities,
-        industry_ids: [], interest_ids: [], metro_ids: [],
+        opportunity_type_ids: [], industry_ids: [], interest_ids: [], metro_ids: [],
         contact_attributes: [:id, :address_1, :address_2, :city, :state, :postal_code, :phone, :email, :url]
       )
     end

--- a/app/controllers/fellow/profiles_controller.rb
+++ b/app/controllers/fellow/profiles_controller.rb
@@ -28,7 +28,7 @@ class Fellow::ProfilesController < ApplicationController
       :key, :first_name, :last_name, :graduation_year, :graduation_semester,
       :major, :affiliations, :linkedin_url, :receive_opportunities, :resume,
       :employment_status_id, :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
-      industry_ids: [], interest_ids: [], metro_ids: [],
+      opportunity_type_ids: [], industry_ids: [], interest_ids: [], metro_ids: [],
       contact_attributes: [:id, :address_1, :address_2, :city, :state, :postal_code, :phone, :email, :url]
     )
   end

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -17,6 +17,8 @@ class Fellow < ApplicationRecord
   has_many :cohorts, through: :cohort_fellows
   has_many :fellow_opportunities
   has_many :career_steps
+  
+  has_and_belongs_to_many :opportunity_types
 
   taggable :industries, :interests, :majors, :industry_interests, :metros
   

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -36,6 +36,7 @@ class Fellow < ApplicationRecord
   
   before_create :generate_key
   after_create :generate_career_steps
+  after_create :select_all_opportunity_types
   after_save :attempt_fellow_match, if: :missing_user?
   
   scope :receive_opportunities, -> { where(receive_opportunities: true) }
@@ -159,6 +160,10 @@ class Fellow < ApplicationRecord
   
   def ignore_opportunities!
     update receive_opportunities: false
+  end
+  
+  def select_all_opportunity_types
+    self.opportunity_types << OpportunityType.all
   end
   
   private

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -163,7 +163,7 @@ class Fellow < ApplicationRecord
   end
   
   def select_all_opportunity_types
-    self.opportunity_types << OpportunityType.all
+    self.opportunity_types << OpportunityType.all if self.opportunity_types.empty?
   end
   
   private

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -40,6 +40,8 @@ class Opportunity < ApplicationRecord
     
     candidate_ids = Fellow.receive_opportunities.pluck(:id)
     
+    candidate_ids &= fellow_ids_for_opportunity_type
+    
     unless search_params[:industries_interests] == ''
       candidate_ids &= fellow_ids_for_industries_interests(search_params[:industries_interests])
     end
@@ -58,6 +60,10 @@ class Opportunity < ApplicationRecord
   
   def formatted_name
     [employer.name, name].join(' - ')
+  end
+  
+  def fellow_ids_for_opportunity_type
+    self.class.connection.query("select fellow_id from fellows_opportunity_types where opportunity_type_id = #{opportunity_type.id}").flatten.uniq
   end
   
   def fellow_ids_for_interests names

--- a/app/models/opportunity_type.rb
+++ b/app/models/opportunity_type.rb
@@ -1,6 +1,8 @@
 class OpportunityType < ApplicationRecord
   has_many :opportunities
   
+  has_and_belongs_to_many :fellows
+  
   validates :name, :position, presence: true, uniqueness: true
   
   class << self

--- a/app/views/admin/fellows/_form.html.erb
+++ b/app/views/admin/fellows/_form.html.erb
@@ -84,19 +84,8 @@
   <hr>
 
   <%= render 'admin/contacts/nested_form', form: form %>
-  
-  <div id="opportunity-types-collection">
-    <h3>Desired Positions</h3>
-  
-    <p>
-      <% OpportunityType.order(position: :asc).each do |opportunity_type| %>
-        <% tag_id = "fellow_opportunity_type_id_#{opportunity_type.id}"%>
-        
-        <%= check_box_tag("fellow[opportunity_type_ids][]", opportunity_type.id, fellow.opportunity_types.include?(opportunity_type), id: tag_id) %>
-        <%= label_tag(tag_id, opportunity_type.name, style: 'display: inline;') %><br>
-      <% end %>
-    </p>
-  </div>
+
+  <%= render 'admin/opportunity_types/check_boxes', fellow: fellow %>
   
   <div id="interests-collection">
     <h3>Industries/Interests/Majors</h3>

--- a/app/views/admin/fellows/_form.html.erb
+++ b/app/views/admin/fellows/_form.html.erb
@@ -85,6 +85,19 @@
 
   <%= render 'admin/contacts/nested_form', form: form %>
   
+  <div id="opportunity-types-collection">
+    <h3>Desired Positions</h3>
+  
+    <p>
+      <% OpportunityType.order(position: :asc).each do |opportunity_type| %>
+        <% tag_id = "fellow_opportunity_type_id_#{opportunity_type.id}"%>
+        
+        <%= check_box_tag("fellow[opportunity_type_ids][]", opportunity_type.id, fellow.opportunity_types.include?(opportunity_type), id: tag_id) %>
+        <%= label_tag(tag_id, opportunity_type.name, style: 'display: inline;') %><br>
+      <% end %>
+    </p>
+  </div>
+  
   <div id="interests-collection">
     <h3>Industries/Interests/Majors</h3>
 

--- a/app/views/admin/opportunity_types/_check_boxes.html.erb
+++ b/app/views/admin/opportunity_types/_check_boxes.html.erb
@@ -1,0 +1,12 @@
+<div id="opportunity-types-collection">
+  <h3>Desired Positions</h3>
+
+  <p>
+    <% OpportunityType.order(position: :asc).each do |opportunity_type| %>
+      <% tag_id = "fellow_opportunity_type_id_#{opportunity_type.id}"%>
+      
+      <%= check_box_tag("fellow[opportunity_type_ids][]", opportunity_type.id, fellow.opportunity_types.include?(opportunity_type), id: tag_id) %>
+      <%= label_tag(tag_id, opportunity_type.name, style: 'display: inline;') %><br>
+    <% end %>
+  </p>
+</div>

--- a/app/views/fellow/profiles/_form.html.erb
+++ b/app/views/fellow/profiles/_form.html.erb
@@ -73,6 +73,19 @@
     <%= form.label :receive_opportunities, 'Receive Career Opportunties from Braven?', class: 'checkbox' %>
   </div>
 
+  <div id="opportunity-types-collection">
+    <h3>Desired Positions</h3>
+  
+    <p>
+      <% OpportunityType.order(position: :asc).each do |opportunity_type| %>
+        <% tag_id = "fellow_opportunity_type_id_#{opportunity_type.id}"%>
+        
+        <%= check_box_tag("fellow[opportunity_type_ids][]", opportunity_type.id, fellow.opportunity_types.include?(opportunity_type), id: tag_id) %>
+        <%= label_tag(tag_id, opportunity_type.name, style: 'display: inline;') %><br>
+      <% end %>
+    </p>
+  </div>
+
   <h3 id="info-interests">Industries and Interests</h3>
   
   <%= link_to 'full industries/interests list', combined_admin_industries_path, target: '_blank' %>

--- a/app/views/fellow/profiles/_form.html.erb
+++ b/app/views/fellow/profiles/_form.html.erb
@@ -73,18 +73,7 @@
     <%= form.label :receive_opportunities, 'Receive Career Opportunties from Braven?', class: 'checkbox' %>
   </div>
 
-  <div id="opportunity-types-collection">
-    <h3>Desired Positions</h3>
-  
-    <p>
-      <% OpportunityType.order(position: :asc).each do |opportunity_type| %>
-        <% tag_id = "fellow_opportunity_type_id_#{opportunity_type.id}"%>
-        
-        <%= check_box_tag("fellow[opportunity_type_ids][]", opportunity_type.id, fellow.opportunity_types.include?(opportunity_type), id: tag_id) %>
-        <%= label_tag(tag_id, opportunity_type.name, style: 'display: inline;') %><br>
-      <% end %>
-    </p>
-  </div>
+  <%= render 'admin/opportunity_types/check_boxes', fellow: fellow %>
 
   <h3 id="info-interests">Industries and Interests</h3>
   

--- a/bin/backup
+++ b/bin/backup
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose exec database pg_dump -U postgres career-mgr_development > tmp/backup.sql

--- a/db/migrate/20180907144539_add_join_table_for_fellow_opportunity_types.rb
+++ b/db/migrate/20180907144539_add_join_table_for_fellow_opportunity_types.rb
@@ -1,0 +1,8 @@
+class AddJoinTableForFellowOpportunityTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :fellows, :opportunity_types do |t|
+      t.index :fellow_id
+      t.index :opportunity_type_id
+    end
+  end
+end

--- a/db/migrate/20180910151757_opt_fellows_into_all_opportunity_types.rb
+++ b/db/migrate/20180910151757_opt_fellows_into_all_opportunity_types.rb
@@ -1,0 +1,12 @@
+class OptFellowsIntoAllOpportunityTypes < ActiveRecord::Migration[5.2]
+  def change
+    count = 0
+    Fellow.all.each do |fellow|
+      fellow.select_all_opportunity_types
+      count += 1
+      $stdout.print '.'; $stdout.flush
+    end
+    
+    print "\nOpted #{count} fellows into all opportunity types"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_07_144539) do
+ActiveRecord::Schema.define(version: 2018_09_10_151757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_06_203137) do
+ActiveRecord::Schema.define(version: 2018_09_07_144539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -253,6 +253,13 @@ ActiveRecord::Schema.define(version: 2018_09_06_203137) do
     t.bigint "metro_id", null: false
     t.index ["fellow_id"], name: "index_fellows_metros_on_fellow_id"
     t.index ["metro_id"], name: "index_fellows_metros_on_metro_id"
+  end
+
+  create_table "fellows_opportunity_types", id: false, force: :cascade do |t|
+    t.bigint "fellow_id", null: false
+    t.bigint "opportunity_type_id", null: false
+    t.index ["fellow_id"], name: "index_fellows_opportunity_types_on_fellow_id"
+    t.index ["opportunity_type_id"], name: "index_fellows_opportunity_types_on_opportunity_type_id"
   end
 
   create_table "industries", force: :cascade do |t|

--- a/spec/controllers/admin/fellows_controller_spec.rb
+++ b/spec/controllers/admin/fellows_controller_spec.rb
@@ -162,6 +162,18 @@ RSpec.describe Admin::FellowsController, type: :controller do
         expect(fellow.reload.resume.attached?).to eq(true)
       end
 
+      it "updates the opportunity types" do
+        fellow = Fellow.create! valid_attributes
+        this_type = create :opportunity_type
+        that_type = create :opportunity_type
+        
+        put :update, params: {id: fellow.to_param, fellow: {opportunity_type_ids: [this_type.id]}}, session: valid_session
+        fellow.reload
+        
+        expect(fellow.opportunity_types).to include(this_type)
+        expect(fellow.opportunity_types).to_not include(that_type)
+      end
+
       it "redirects to the fellow" do
         fellow = Fellow.create! valid_attributes
         put :update, params: {id: fellow.to_param, fellow: valid_attributes}, session: valid_session

--- a/spec/controllers/fellow/profiles_controller_spec.rb
+++ b/spec/controllers/fellow/profiles_controller_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe Fellow::ProfilesController, type: :controller do
         
         expect(fellow.receive_opportunities).to eq(false)
       end
+      
+      it "updates the opportunity types" do
+        this_type = create :opportunity_type
+        that_type = create :opportunity_type
+        
+        put :update, params: {fellow: {opportunity_type_ids: [this_type.id]}}, session: valid_session
+        fellow.reload
+        
+        expect(fellow.opportunity_types).to include(this_type)
+        expect(fellow.opportunity_types).to_not include(that_type)
+      end
 
       it "redirects to the industries list" do
         put :update, params: {fellow: {last_name: new_last_name}}, session: valid_session

--- a/spec/features/candidates_views_spec.rb
+++ b/spec/features/candidates_views_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Candidate Views", type: :feature do
   let(:metro_other) { create :metro }
   
   let(:employer) { create :employer }
-  let(:opportunity) { create :opportunity, employer: employer, metro_ids: [metro.id] }
+  let(:opportunity) { create :opportunity, employer: employer, metro_ids: [metro.id], opportunity_type: opportunity_type }
   
   let(:fellow) { create :fellow }
   let(:contact_fellow) { create :contact, contactable: fellow, postal_code: postal_code.code }
@@ -32,6 +32,8 @@ RSpec.feature "Candidate Views", type: :feature do
   
   let(:opportunity_stage) { create :opportunity_stage, name: 'First', position: 0, probability: 0.1 }
   let(:opportunity_stage_next) { create :opportunity_stage, name: 'Second', position: 1, probability: 0.2 }
+  
+  let(:opportunity_type) { create :opportunity_type }
   
   background do
     opportunity_stage; opportunity_stage_next
@@ -48,11 +50,13 @@ RSpec.feature "Candidate Views", type: :feature do
     fellow.industries << industry
     fellow.interests << interest
     fellow.metros << metro
+    fellow.opportunity_types << opportunity_type
     expect(Metro.count).to eq(2)
     
     fellow_other.industries << industry_other
     fellow_other.interests << interest_other
     fellow_other.metros << metro_other
+    fellow_other.opportunity_types << opportunity_type
     expect(Metro.count).to eq(2)
     
     expect(Employer.count).to eq(1)

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -124,6 +124,13 @@ RSpec.describe Fellow, type: :model do
     end
   end
   
+  describe 'opportunity_type selection' do
+    it "selects all upon create" do
+      expect_any_instance_of(Fellow).to receive(:select_all_opportunity_types).once
+      create :fellow
+    end
+  end
+  
   ###############
   # Normalization
   ###############
@@ -447,6 +454,31 @@ RSpec.describe Fellow, type: :model do
       
       fellow.reload
       expect(fellow.receive_opportunities).to eq(false)
+    end
+  end
+  
+  describe '#select_all_opportunity_types' do
+    let(:fellow) { create :fellow }
+    let(:type1) { create :opportunity_type }
+    let(:type2) { create :opportunity_type }
+    let(:type3) { create :opportunity_type }
+    
+    before { fellow.opportunity_types = []; type1; type2; type3 }
+    
+    subject { fellow.select_all_opportunity_types; fellow.opportunity_types }
+    
+    describe 'when fellow has no opportunity types selected' do
+      it { should include(type1) }
+      it { should include(type2) }
+      it { should include(type3) }
+    end
+    
+    describe 'when fellow has some opportunity types selected' do
+      before { fellow.opportunity_types = [type1, type2] }
+      
+      it { should include(type1) }
+      it { should include(type2) }
+      it { should include(type3) }
     end
   end
 end

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Fellow, type: :model do
   it { should have_and_belong_to_many :industries }
   it { should have_and_belong_to_many :majors }
   it { should have_and_belong_to_many :metros }
+  it { should have_and_belong_to_many :opportunity_types }
   
   it { should belong_to :employment_status }
   it { should belong_to :user }

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -478,7 +478,7 @@ RSpec.describe Fellow, type: :model do
       
       it { should include(type1) }
       it { should include(type2) }
-      it { should include(type3) }
+      it { should_not include(type3) }
     end
   end
 end

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Opportunity, type: :model do
     let(:major_parent) { create :major }
     let(:major_child) { create :major, parent: major_parent }
     let(:metro) { create :metro }
+    let(:opportunity_type) { create :opportunity_type }
     
     def matching_industry
       opportunity.industries << industry
@@ -156,12 +157,24 @@ RSpec.describe Opportunity, type: :model do
       fellow.update receive_opportunities: false
     end
     
+    before do
+      opportunity.opportunity_type = opportunity_type
+      fellow.opportunity_types << opportunity_type
+    end
+    
     describe 'with matching metro' do
       before { matching_metro }
     
       it "includes fellow when there is a shared interest" do
         matching_interest
         expect(opportunity.candidates).to include(fellow)
+      end
+    
+      it "excludes fellow when fellow does not share overlap opportunity types" do
+        matching_interest
+        fellow.opportunity_types = []
+        
+        expect(opportunity.candidates).to_not include(fellow)
       end
     
       it "excludes fellow when fellow does not share the interest" do

--- a/spec/models/opportunity_type_spec.rb
+++ b/spec/models/opportunity_type_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe OpportunityType, type: :model do
   
   it { should have_many :opportunities }
   
+  it { should have_and_belong_to_many :fellows }
+  
   #############
   # Validations
   #############


### PR DESCRIPTION
Fellows can now denote what types of job opportunities they're interested in. We filter against these preferences during candidate searches, to avoid sending fellows those opportunities that don't match their current needs. Admin can also update this info about a given fellow.

**UPDATE:** Fellows need to be added to all opp types by default! We want them to opt out of types, not have to opt in. Otherwise, imported uses won't have any opp types selected. This has been corrected.

**screencap:** https://vimeo.com/289102082/bf69616889

![20180910-job-types](https://user-images.githubusercontent.com/12893/45306166-9ed1f000-b4e1-11e8-8957-3d18339ed3e5.png)
