### PR TITLE
Staff-Requested Opportunity Improvements

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,8 +28,7 @@ body {
 }
 
 main {
-  width: 672px;
-  margin: 0 auto 5vw;
+  margin: 0 5vw;
   position: relative;
 }
 
@@ -480,4 +479,8 @@ form#opportunity-filters {
 
 td.numeric {
   text-align: right;
+}
+
+td.checkmark {
+  text-align: center;
 }

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -109,7 +109,7 @@ class Admin::OpportunitiesController < ApplicationController
   def opportunity_params
     params.require(:opportunity).permit(
       :_destroy,
-      :name, :description, :employer_id, :job_posting_url, :application_deadline, 
+      :name, :summary, :employer_id, :job_posting_url, :application_deadline, 
       :inbound, :recurring, :opportunity_type_id, :region_id, :how_to_apply,
       :industry_tags, :interest_tags, :metro_tags, :industry_interest_tags,
       steps: [],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,4 +58,9 @@ module ApplicationHelper
   def checkmark boolean
     boolean ? '&#x2714;'.html_safe : ''
   end
+  
+  def paragraph_format text
+    cleaned_text = text.gsub(/\r/, '').gsub(/\n+/, '</p><p>')
+    "<p>#{cleaned_text}</p>".html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,4 +54,8 @@ module ApplicationHelper
   def nlu_login
     "#{Rails.application.secrets.nlu_sso_url}login?service=#{sso_encode}"
   end
+  
+  def checkmark boolean
+    boolean ? '&#x2714;'.html_safe : ''
+  end
 end

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -37,8 +37,8 @@
   </div>
 
   <div class="field">
-    <%= form.label :description, 'Description (please keep it short!)' %>
-    <%= form.text_area :description %>
+    <%= form.label :summary, 'Summary (please keep it short!)' %>
+    <%= form.text_area :summary %>
   </div>
 
   <div class="field">

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -14,6 +14,10 @@
           <th>Employer</th>
           <th>Title</th>
           <th>Description</th>
+          <th>Published</th>
+          <th>Partner</th>
+          <th>Inbound</th>
+          <th>Recurring</th>
           <th colspan="3">Actions</th>
           <th>Export</th>
         </tr>
@@ -25,6 +29,10 @@
             <td><%= opportunity.employer.name %>
             <td><%= link_to opportunity.name, admin_opportunity_path(opportunity) %></td>
             <td><%= truncate(opportunity.description, length: 100, separator: ' ') %></td>
+            <td class="checkmark"><%= checkmark(opportunity.published?) %></td>
+            <td class="checkmark"><%= checkmark(opportunity.employer.employer_partner) %>
+            <td class="checkmark"><%= checkmark(opportunity.inbound) %></td>
+            <td class="checkmark"><%= checkmark(opportunity.recurring) %></td>
             <td><%= link_to 'Edit', edit_admin_opportunity_path(opportunity), class: 'edit' %></td>
             <td><%= link_to 'Delete', admin_opportunity_path(opportunity), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %></td>
             <td><%= link_to('Unpublish', unpublish_admin_opportunity_path(opportunity), method: :put, class: 'edit') if opportunity.published? %></td>

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -13,7 +13,7 @@
         <tr>
           <th>Employer</th>
           <th>Title</th>
-          <th>Description</th>
+          <th>Summary</th>
           <th>Published</th>
           <th>Partner</th>
           <th>Inbound</th>
@@ -28,7 +28,7 @@
           <tr>
             <td><%= opportunity.employer.name %>
             <td><%= link_to opportunity.name, admin_opportunity_path(opportunity) %></td>
-            <td><%= truncate(opportunity.description, length: 100, separator: ' ') %></td>
+            <td><%= truncate(opportunity.summary, length: 100, separator: ' ') %></td>
             <td class="checkmark"><%= checkmark(opportunity.published?) %></td>
             <td class="checkmark"><%= checkmark(opportunity.employer.employer_partner) %>
             <td class="checkmark"><%= checkmark(opportunity.inbound) %></td>

--- a/app/views/admin/opportunities/_opportunity.json.jbuilder
+++ b/app/views/admin/opportunities/_opportunity.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! opportunity, :id, :name, :description, :employer_id, :created_at, :updated_at
+json.extract! opportunity, :id, :name, :summary, :employer_id, :created_at, :updated_at
 json.url admin_opportunity_url(opportunity, format: :json)

--- a/app/views/admin/opportunities/show.html.erb
+++ b/app/views/admin/opportunities/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 <p>
   <strong>Job Posting URL:</strong>
-  <%= link_to @opportunity.job_posting_url %>
+  <%= link_to @opportunity.job_posting_url, @opportunity.job_posting_url, target: '_blank' %>
 </p>
 <p>
   <strong>Summary:</strong>

--- a/app/views/admin/opportunities/show.html.erb
+++ b/app/views/admin/opportunities/show.html.erb
@@ -12,8 +12,8 @@
   <%= link_to @opportunity.job_posting_url %>
 </p>
 <p>
-  <strong>Description:</strong>
-  <%= @opportunity.description %>
+  <strong>Summary:</strong>
+  <%= @opportunity.summary %>
 </p>
 <p>
   <strong>How to Apply:</strong>

--- a/app/views/admin/opportunities/show.html.erb
+++ b/app/views/admin/opportunities/show.html.erb
@@ -9,7 +9,7 @@
 </p>
 <p>
   <strong>Job Posting URL:</strong>
-  <%= @opportunity.job_posting_url %>
+  <%= link_to @opportunity.job_posting_url %>
 </p>
 <p>
   <strong>Description:</strong>

--- a/app/views/candidate_mailer/respond_to_invitation.html.erb
+++ b/app/views/candidate_mailer/respond_to_invitation.html.erb
@@ -2,10 +2,9 @@
 
 <p>You have been selected to apply for the following opportunity:</p>
 
-<p>
-  <strong><%= @opp.name %></strong><br>
-  other details here.
-</p>
+<p><strong><%= @opp.name %></strong></p>
+
+<%= paragraph_format @opp.summary %>
 
 <p>Please let us know if you're interested in this opportunity:</p>
 

--- a/app/views/fellow/opportunities/show.html.erb
+++ b/app/views/fellow/opportunities/show.html.erb
@@ -1,7 +1,7 @@
 <h1><%= @candidate.opportunity.formatted_name %></h1>
 <p>
-  <strong>Description:</strong>
-  <%= @candidate.opportunity.description %>
+  <strong>Summary:</strong>
+  <%= @candidate.opportunity.summary %>
 </p>
 <p>
   <strong>How to Apply:</strong>

--- a/db/migrate/20180910182323_rename_description_to_summary_in_opportunities.rb
+++ b/db/migrate/20180910182323_rename_description_to_summary_in_opportunities.rb
@@ -1,0 +1,7 @@
+class RenameDescriptionToSummaryInOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    change_table :opportunities do |t|
+      t.rename :description, :summary
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_10_151757) do
+ActiveRecord::Schema.define(version: 2018_09_10_182323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -354,7 +354,7 @@ ActiveRecord::Schema.define(version: 2018_09_10_151757) do
 
   create_table "opportunities", force: :cascade do |t|
     t.string "name"
-    t.text "description"
+    t.text "summary"
     t.integer "employer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/opportunities.rb
+++ b/spec/factories/opportunities.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :opportunity do
     sequence(:name) {|i| "Opportunity #{i}"}
-    description "Description"
+    summary "Summary"
     job_posting_url "https://example.com"
 
     association :employer

--- a/spec/features/opportunities_views_spec.rb
+++ b/spec/features/opportunities_views_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "OpportunityViews", type: :feature do
     opportunity_attributes = attributes_for :opportunity
 
     fill_in 'Opportunity Name or Job Title', with: opportunity_attributes[:name]
-    fill_in 'Description', with: opportunity_attributes[:description]
+    fill_in 'Summary', with: opportunity_attributes[:summary]
 
     click_on '+add a location'
 
@@ -65,7 +65,7 @@ RSpec.feature "OpportunityViews", type: :feature do
     click_on 'Create Opportunity'
     opportunity = Opportunity.last
 
-    [:name, :description, :job_posting_url].each do |attr|
+    [:name, :summary, :job_posting_url].each do |attr|
       expect(opportunity.send(attr)).to eq(opportunity_attributes[attr])
     end
 
@@ -115,8 +115,8 @@ RSpec.feature "OpportunityViews", type: :feature do
     updated_name = opportunity.name + 'x'
     fill_in 'Opportunity Name or Job Title', with: updated_name
 
-    updated_desc = opportunity.description + 'x'
-    fill_in 'Description', with: updated_desc
+    updated_summary = opportunity.summary + 'x'
+    fill_in 'Summary', with: updated_summary
     
     expect_list_link_for 'industries/interests', link: 'full list', within: '#interests-collection'
     expect_list_link_for :metro_areas, link: 'full list', within: '#metros-collection'
@@ -134,7 +134,7 @@ RSpec.feature "OpportunityViews", type: :feature do
 
     opportunity.reload
     expect(opportunity.name).to eq(updated_name)
-    expect(opportunity.description).to eq(updated_desc)
+    expect(opportunity.summary).to eq(updated_summary)
 
     expect(opportunity.industries).to include(industry_excluded)
     expect(opportunity.industries).to_not include(industry_included)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -117,4 +117,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { should eq("N/A") }
     end
   end
+  
+  describe '#checkmark(boolean)' do
+    subject { checkmark(boolean) }
+    
+    describe 'when boolean is true' do
+      let(:boolean) { true }
+      it { should eq('&#x2714;'.html_safe) }
+    end
+    
+    describe 'when boolean is false' do
+      let(:boolean) { false }
+      it { should be_blank }
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -131,4 +131,29 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { should be_blank }
     end
   end
+  
+  describe '#paragraph_format(text)' do
+    subject { paragraph_format(text) }
+    
+    describe 'when text has only one paragraph' do
+      let(:text) { 'This is short text.' }
+
+      it { should eq("<p>This is short text.</p>") }
+      it { should be_html_safe }
+    end
+    
+    describe 'when text has newlines' do
+      let(:text) { "Test\nTest\n\nTest" }
+
+      it { should eq("<p>Test</p><p>Test</p><p>Test</p>") }
+      it { should be_html_safe }
+    end
+    
+    describe 'when text uses carriage returns as well as newlines' do
+      let(:text) { "Test\r\nTest\r\n\r\nTest" }
+
+      it { should eq("<p>Test</p><p>Test</p><p>Test</p>") }
+      it { should be_html_safe }
+    end
+  end
 end


### PR DESCRIPTION
This recent update includes a handful of staff-requested changes to opportunities:

* Descriptions are now called summaries, to reflect the fact that they should be short ways to convey info about an opportunity.
* Job Posting URLs are now clickable links when viewing an opportunity. They open in their own tab.
* The opportunities lists now include info about the attributes that determine priority - published status, employer partner, inbound, or recurring. Since all of these are boolean (yes/no), they're represented with checkboxes for easy viewing.

**screencap:** https://vimeo.com/289145488/5c7462dba7

![20180910-staff-requests](https://user-images.githubusercontent.com/12893/45318587-00ef1d00-b503-11e8-94c7-684e2b0cbc7d.png)
