### PR TITLE
Tagging Improvements in Forms

### DIFF
--- a/app/assets/javascripts/fellows.coffee
+++ b/app/assets/javascripts/fellows.coffee
@@ -41,7 +41,24 @@ $(document).on "turbolinks:load",  ->
         
           $("##{element}-checklist").hide()
           $("##{element}-tags").show()
-        
+
+  preventPartialTags = () ->
+    $('form').submit (event) ->
+      $('.jquery-tags input').each ->
+        if $(this).val().length > 0
+          event.preventDefault()
+          
+          leftover = $(this).val()
+          label = $(this).parents('.jquery-tags').prevAll('h3').text()
+          
+          alert("Please complete or remove your search for \"#{leftover}\" in \"#{label}\"")
+          setTimeout(reenableSubmit, 1000)
+  
+  reenableSubmit = () ->
+    $('form input[type="submit"]').removeAttr('disabled', 'false')
+          
   enableFellowTagChecklistToggle("interest", '/admin/interests/list.json', 'Add an Interest')
   enableFellowTagChecklistToggle("industry", '/admin/industries/list.json', 'Add an Industry')
   enableFellowTagChecklistToggle("metro",    '/admin/metros/list.json', 'Add a Location')
+
+  preventPartialTags()

--- a/lib/taggable.rb
+++ b/lib/taggable.rb
@@ -33,7 +33,7 @@ module Taggable
   
   module IndustryMethods
     def industry_tags
-      industries.pluck(:name).join(';')
+      Industry.where(id: self.industry_ids).pluck(:name).join(';')
     end
   
     def industry_tags= tag_string
@@ -43,7 +43,7 @@ module Taggable
   
   module InterestMethods
     def interest_tags
-      interests.pluck(:name).join(';')
+      Interest.where(id: self.interest_ids).pluck(:name).join(';')
     end
   
     def interest_tags= tag_string
@@ -53,7 +53,7 @@ module Taggable
   
   module MajorMethods
     def major_tags
-      majors.pluck(:name).join(';')
+      Major.where(id: self.major_ids).pluck(:name).join(';')
     end
   
     def major_tags= tag_string
@@ -63,7 +63,7 @@ module Taggable
   
   module IndustryInterestMethods
     def industry_interest_tags
-      (industries.pluck(:name) | interests.pluck(:name) | majors.pluck(:name)).sort.join(';')
+      (industry_tags.split(';') | interest_tags.split(';') | major_tags.split(';')).sort.join(';')
     end
   
     def industry_interest_tags= tag_string
@@ -75,7 +75,7 @@ module Taggable
   
   module MetroMethods
     def metro_tags
-      metros.pluck(:name).join(';')
+      Metro.where(id: self.metro_ids).pluck(:name).join(';')
     end
   
     def metro_tags= tag_string

--- a/spec/features/opportunities_views_spec.rb
+++ b/spec/features/opportunities_views_spec.rb
@@ -64,6 +64,8 @@ RSpec.feature "OpportunityViews", type: :feature do
 
     click_on 'Create Opportunity'
     opportunity = Opportunity.last
+    
+    expect(page).to have_content("successfully created")
 
     [:name, :summary, :job_posting_url].each do |attr|
       expect(opportunity.send(attr)).to eq(opportunity_attributes[attr])

--- a/spec/support/taggable_helpers.rb
+++ b/spec/support/taggable_helpers.rb
@@ -1,11 +1,14 @@
 RSpec.shared_examples "taggable" do |object_type, taggable_type|
   describe "#{taggable_type}_tags" do
     it "returns a semicolon-delimited list of associated #{taggable_type} names" do
-      object = build object_type
-      taggable_1 = build taggable_type, name: 'Taggable 1'
-      taggable_2 = build taggable_type, name: 'Taggable 2'
-  
-      allow(object).to receive(taggable_type.to_s.pluralize.to_sym).and_return([taggable_1, taggable_2])
+      object = create object_type
+      expect(object).to be_valid
+      taggable_1 = create taggable_type, name: 'Taggable 1'
+      expect(taggable_1).to be_valid
+      taggable_2 = create taggable_type, name: 'Taggable 2'
+      expect(taggable_2).to be_valid
+      
+      object.send(:"#{taggable_type}_ids=", [taggable_1, taggable_2].map(&:id))
   
       expect(object.send(:"#{taggable_type}_tags")).to eq("Taggable 1;Taggable 2")
     end
@@ -32,18 +35,18 @@ end
 RSpec.shared_examples "taggable_combined" do |object_type, taggable_type_a, taggable_type_b|
   describe "##{taggable_type_a}_#{taggable_type_b}_tags" do
     it "returns a semicolon-delimited list of unique associated #{taggable_type_a} AND #{taggable_type_b} names" do
-      object = build object_type
+      object = create object_type
       
-      taggable_a_1 = build taggable_type_a, name: 'Taggable A 1'
-      taggable_a_2 = build taggable_type_a, name: 'Taggable Shared'
-      taggable_b_1 = build taggable_type_b, name: 'Taggable B 1'
-      taggable_b_2 = build taggable_type_b, name: 'Taggable Shared'
+      taggable_a_1 = create taggable_type_a, name: 'Taggable A 1'
+      taggable_a_2 = create taggable_type_a, name: 'Taggable Shared'
+      taggable_b_1 = create taggable_type_b, name: 'Taggable B 1'
+      taggable_b_2 = create taggable_type_b, name: 'Taggable Shared'
       
       taggables_a = taggable_type_a.to_s.pluralize.to_sym
       taggables_b = taggable_type_b.to_s.pluralize.to_sym
 
-      allow(object).to receive(taggables_a).and_return([taggable_a_1, taggable_a_2])
-      allow(object).to receive(taggables_b).and_return([taggable_b_1, taggable_b_2])
+      object.send(:"#{taggable_type_a}_ids=", [taggable_a_1, taggable_a_2].map(&:id))
+      object.send(:"#{taggable_type_b}_ids=", [taggable_b_1, taggable_b_2].map(&:id))
       
       list = object.send(:"#{taggable_type_a}_#{taggable_type_b}_tags").split(';')
 


### PR DESCRIPTION
We've made a couple improvements to tagging in forms:

* when form submission fails because of an error, tag fields are no longer accidentally cleared out. Just like the rest of the form, the tags will still be there and you can focus on only changing what's broken on the form.
* Incomplete tag searches (tag text that has not been converted into an actual tag) will now flag the user so they don't submit the form *thinking* they've added a tag that they haven't.

**screencap:** https://vimeo.com/289375973/667a11294a

![20180911-better-tagging-specs](https://user-images.githubusercontent.com/12893/45390910-ae872c80-b5e6-11e8-9c99-a7480501baa3.png)
