### PR TITLE
Adjust Navigation Links Based on Current User

### DIFF
--- a/app/views/fellow/home/welcome.html.erb
+++ b/app/views/fellow/home/welcome.html.erb
@@ -1,19 +1,18 @@
 <div id="career-progress" class="<%= @fellow.career_steps.all?(&:completed?) ? ' all-done' : '' %>">
   <h1><%= @fellow.first_name %>&rsquo;s Career Dashboard</h1>
 
-  <%= link_to 'View profile details', fellow_profile_path %>
-
   <h2>Career Progress</h2>
 
   <p>Complete these important milestones to set yourself up for successful job hunting. Most of the items can be completed as part of the Braven Accelerator.</p>
 
-
-<%= form_tag fellow_home_career_path, class: 'career-tracker-form' do %>
-  <div id="career-tracker">
-    <% @fellow.career_steps.order(position: 'asc').each do |career_step| %>
-      <% label = "career-item-#{sprintf('%02d', career_step.position + 1)}" %>
+  <%= form_tag fellow_home_career_path, class: 'career-tracker-form' do %>
+    <div id="career-tracker">
+      <% @fellow.career_steps.order(position: 'asc').each do |career_step| %>
+        <% label = "career-item-#{sprintf('%02d', career_step.position + 1)}" %>
+        
         <div class="tracker-item">
           <%= check_box_tag('career_steps[]', career_step.position, career_step.completed, id: label, class: 'career') %>
+          
           <label for="<%= label %>">
             <h4><%= career_step.position + 1 %></h4>
             <p><%= career_step.description %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,23 +22,24 @@
           <div class="bar3"></div>
         </div>
         <nav id="main-nav">
-          <% if true %>
-            <!-- Please replace with relevant if statements and nav items per user type: Fellow, Admin -->
-            <ul>
+          <ul>
+            <% if current_user.is_admin? %>
               <li><%= link_to "Employers", admin_employers_path %> (<%= Employer.count %>)</li>
               <li><%= link_to "Opportunities", admin_opportunities_path %> (<%= Opportunity.count %>)</li>
               <li><%= link_to "Industries", admin_industries_path %> (<%= Industry.count %>)</li>
               <li><%= link_to "Interests", admin_interests_path %> (<%= Interest.count %>)</li>
               <li><%= link_to "Sites", admin_sites_path %> (<%= Site.count %>)</li>
               <li><%= link_to "Fellows", admin_fellows_path %> (<%= Fellow.count %>)</li>
-            </ul>
+            <% elsif current_user.is_fellow? %>
+              <li><%= link_to "Dashboard", fellow_home_welcome_path %></li>
+              <li><%= link_to "Profile", fellow_profile_path %></li>
             <% end %>
-            <% if current_user %>
-              <%= link_to 'Sign Out', destroy_sso_user_session_path, method: :delete, class: 'logout button' %>
-            <% end %>
-          </nav>
-        <% end %>
-      </header>
+          </ul>
+          
+          <%= link_to 'Sign Out', destroy_sso_user_session_path, method: :delete, class: 'logout button' %>
+        </nav>
+      <% end %>
+    </header>
     <main>
       <p id="notice"><%= notice %></p>
       <p id="alert"><%= alert %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,27 +15,29 @@
     <header id="masthead">
       <div id="header-logo">&nbsp;</div>
       <h1><%= link_to 'My Career Manager', root_path %></h1>
+      <% if current_user %>
         <div id="menu-icon" onclick="bzToggleNav(this)">
-        <div class="bar1"></div>
-        <div class="bar2"></div>
-        <div class="bar3"></div>
-      </div>
-      <nav id="main-nav">
+          <div class="bar1"></div>
+          <div class="bar2"></div>
+          <div class="bar3"></div>
+        </div>
+        <nav id="main-nav">
           <% if true %>
-          <!-- Please replace with relevant if statements and nav items per user type: Fellow, Admin -->
-          <ul>
-            <li><%= link_to "Employers", admin_employers_path %> (<%= Employer.count %>)</li>
-            <li><%= link_to "Opportunities", admin_opportunities_path %> (<%= Opportunity.count %>)</li>
-            <li><%= link_to "Industries", admin_industries_path %> (<%= Industry.count %>)</li>
-            <li><%= link_to "Interests", admin_interests_path %> (<%= Interest.count %>)</li>
-            <li><%= link_to "Sites", admin_sites_path %> (<%= Site.count %>)</li>
-            <li><%= link_to "Fellows", admin_fellows_path %> (<%= Fellow.count %>)</li>
-          </ul>
-          <% end %>
-          <% if current_user %>
-            <%= link_to 'Sign Out', destroy_sso_user_session_path, method: :delete, class: 'logout button' %>
-          <% end %>
-        </nav>
+            <!-- Please replace with relevant if statements and nav items per user type: Fellow, Admin -->
+            <ul>
+              <li><%= link_to "Employers", admin_employers_path %> (<%= Employer.count %>)</li>
+              <li><%= link_to "Opportunities", admin_opportunities_path %> (<%= Opportunity.count %>)</li>
+              <li><%= link_to "Industries", admin_industries_path %> (<%= Industry.count %>)</li>
+              <li><%= link_to "Interests", admin_interests_path %> (<%= Interest.count %>)</li>
+              <li><%= link_to "Sites", admin_sites_path %> (<%= Site.count %>)</li>
+              <li><%= link_to "Fellows", admin_fellows_path %> (<%= Fellow.count %>)</li>
+            </ul>
+            <% end %>
+            <% if current_user %>
+              <%= link_to 'Sign Out', destroy_sso_user_session_path, method: :delete, class: 'logout button' %>
+            <% end %>
+          </nav>
+        <% end %>
       </header>
     <main>
       <p id="notice"><%= notice %></p>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -39,6 +39,8 @@ development:
   mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
   mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
   mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
+  test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
+  test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>
 
 test:
   smtp_server: <%= ENV['SMTP_SERVER'] %>
@@ -80,6 +82,8 @@ test:
   mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
   mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
   mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
+  test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
+  test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>
 
 staging:
   secret_key_base: <%= ENV['RAILS_SECRET_TOKEN'] %>
@@ -122,6 +126,8 @@ staging:
   mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
   mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
   mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
+  test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
+  test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>
 
 production:
   smtp_override_recipient: <%= ENV['SMTP_OVERRIDE_RECIPIENT'] %>
@@ -164,3 +170,5 @@ production:
   mailchimp_key: <%= ENV['MAILCHIMP_KEY'] %>
   mailchimp_list_id: <%= ENV['MAILCHIMP_LIST_ID'] %>
   mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
+  test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
+  test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -2,20 +2,22 @@ module FeatureHelper
   def login user_type=:admin
     create :"#{user_type}_user", email: 'admin@beyondz.org' unless User.find_by(email: 'admin@beyondz.org')
     visit root_path
+    
+    logged_in = '#menu-icon'
   
     begin
-      find('a[href="/users/sign_out_sso"]')
+      find(logged_in)
     rescue Capybara::ElementNotFound
       find("img[alt='Braven']").click
 
       begin
-        find('a[href="/users/sign_out_sso"]')
+        find(logged_in)
       rescue
         expect(page).to have_content('PLATFORM LOGIN')
-      
-        fill_in 'username', with: 'admin@beyondz.org'
-        fill_in 'password', with: 'test1234'
-  
+    
+        fill_in 'username', with: Rails.application.secrets.test_sso_username
+        fill_in 'password', with: Rails.application.secrets.test_sso_password
+
         click_on 'Log in'
       end
     end

--- a/spec/features/employers_views_spec.rb
+++ b/spec/features/employers_views_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Employer Views", type: :feature do
 
     expect(page).to have_content(/Editing Employer/i)
     expect(page).to have_content(industry.name)
-    
+
     fill_in 'Name', with: 'New Name'
 
     expect_list_link_for :industries
@@ -77,7 +77,7 @@ RSpec.feature "Employer Views", type: :feature do
     add_tag(:employer, :industry, industry_other.name)
 
     click_on 'Update Employer'
-    
+
     employer.reload
     expect(employer.name).to eq('New Name')
     expect(employer.industries).to_not include(industry)
@@ -85,13 +85,13 @@ RSpec.feature "Employer Views", type: :feature do
 
     expect(page).to have_current_path(admin_employer_path(employer.id))
   end
-  
+
   scenario "Deleting", js: true do
     visit_employers
-    
+
     click_on 'Delete'
     page.driver.browser.switch_to.alert.accept
-    
+
     expect(page).to have_current_path(admin_employers_path)
     expect(page).to have_content("Employer #{employer.name} was successfully deleted.")
     expect(Employer.count).to eq(0)

--- a/spec/features/fellows_views_spec.rb
+++ b/spec/features/fellows_views_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "FellowViews", type: :feature do
     fill_in 'First name', with: fellow_attributes[:first_name]
     fill_in 'Last name', with: fellow_attributes[:last_name]
     fill_in 'Graduation year', with: fellow_attributes[:graduation_year]
-    select fellow_attributes[:graduation_semester], from: 'Graduation semester'
+    select fellow_attributes[:graduation_semester], from: 'Graduation term'
     
     contact_attributes = attributes_for :contact
     


### PR DESCRIPTION
We needed a different set of navigation links for fellows, vs admins. We also needed to fix broken feature specs, because the layout change broke how we determine if a user is logged in.

![20180913-specs](https://user-images.githubusercontent.com/12893/45501917-39336d00-b748-11e8-9179-0649b54f06e9.png)
