### PR TITLE
Fix candidate update notices

### DIFF
--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -4,7 +4,7 @@ class CandidatesController < ApplicationController
   def status
     if @fellow_opportunity = FellowOpportunity.find_by(id: params[:fellow_opportunity_id])
       update = params[:update].downcase
-      notice = @fellow_opportunity.opportunity_stage.content['notices'][update]
+      notice = @fellow_opportunity.notice_for(update)
       
       @fellow_opportunity.update_stage(update, from: params[:from])
       

--- a/app/models/fellow_opportunity.rb
+++ b/app/models/fellow_opportunity.rb
@@ -63,6 +63,14 @@ class FellowOpportunity < ApplicationRecord
     self.update active: false
   end
   
+  def notice_for update
+    if opportunity_stage && opportunity_stage.content && opportunity_stage.content['notices']
+      opportunity_stage.content['notices'][update]
+    else
+      nil
+    end
+  end
+  
   private
   
   def next_opportunity_stage from=nil

--- a/spec/models/fellow_opportunity_spec.rb
+++ b/spec/models/fellow_opportunity_spec.rb
@@ -228,4 +228,41 @@ RSpec.describe FellowOpportunity, type: :model do
       expect(fellow_opportunity.logs.last.status).to eq(status_message)
     end
   end
+  
+  describe '#notice_for(update)' do
+    let(:fellow) { build :fellow }
+    let(:fellow_opportunity) { build :fellow_opportunity, fellow: fellow, opportunity_stage: opportunity_stage }
+    let(:opportunity_stage) { build :opportunity_stage, name: stage_name }
+    let(:stage_name) { 'research employer' }
+    let(:update) { 'next' }
+    let(:yaml) { {'research employer' => {'notices' => {'next' => 'hello'}}} }
+    
+    before { allow(YAML).to receive(:load).and_return(yaml) }
+    
+    subject { fellow_opportunity.notice_for(update) }
+
+    describe 'when notice exists' do
+      it { should eq('hello') }
+    end
+    
+    describe 'when content exists for stage, but update does not' do
+      let(:update) { 'other' }
+      it { should be_nil }
+    end
+    
+    describe 'when content doesn\'t exist at all for stage' do
+      let(:stage_name) { 'other' }
+      it { should be_nil }
+    end
+    
+    describe 'when content doesn\t have notices' do
+      let(:yaml) { {'research employer' => {'other' => {'next' => 'hello'}}} }
+      it { should be_nil }
+    end
+    
+    describe 'when opportunity stage doesn\'t exist' do
+      let(:opportunity_stage) { nil }
+      it { should be_nil }
+    end
+  end
 end


### PR DESCRIPTION
We have notices that get displayed when a fellow's opportunity transitions from one status to another. This fails (raises an exception) when an unconventional transition is made (ie, from declined to anything else).

![20180915-specs](https://user-images.githubusercontent.com/12893/45565915-cd6e0480-b81a-11e8-8e2e-3827cb0f71b8.png)
