### PR TITLE
Prepopulate opps with employer industries

### DIFF
--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -31,6 +31,7 @@ class Admin::OpportunitiesController < ApplicationController
   def new
     @opportunity = @opportunities.build
     @opportunity.tasks.build
+    @opportunity.set_default_industries
   end
 
   # GET /opportunities/1/edit

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -225,6 +225,10 @@ class Opportunity < ApplicationRecord
     update published: false
   end
   
+  def set_default_industries
+    self.industry_ids = employer.industry_ids
+  end
+  
   private
   
   def archived_fellow_opp candidate_id

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -236,6 +236,11 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
         get :new, params: {employer_id: employer.id}, session: valid_session
         expect(response).to be_successful
       end
+
+      it "sets the default industry_ids" do
+        expect_any_instance_of(Opportunity).to receive(:set_default_industries).once
+        get :new, params: {employer_id: employer.id}, session: valid_session
+      end
     end
 
     describe "POST #create" do

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -486,4 +486,28 @@ RSpec.describe Opportunity, type: :model do
       it { should eq(false) }
     end
   end
+  
+  describe '#set_default_industries' do
+    let(:industry_included) { create :industry } 
+    let(:industry_excluded) { create :industry } 
+    let(:employer) { create :employer }
+    
+    before { employer.industry_ids << industry_included.id }
+    
+    subject { o = Opportunity.new employer: chosen_employer; o.set_default_industries; o.industry_ids }
+    
+    describe 'when employer has industries' do
+      let(:chosen_employer) { employer }
+      
+      it { should include(industry_included.id) }
+      it { should_not include(industry_excluded.id) }
+    end
+    
+    describe 'when employer has no industries' do
+      let(:chosen_employer) { create :employer }
+      
+      it { should_not include(industry_included.id) }
+      it { should_not include(industry_excluded.id) }
+    end
+  end
 end


### PR DESCRIPTION
Opportunities should, by default, be tagged with the same industries as the employer they came from. That won't always be a good fit, but it's a great default. New opportunities now have their employer's industries pre-populated in the industries/interests tag field.

**screencap:** https://vimeo.com/289933168/6d6e9bdc24

![20180915b-specs](https://user-images.githubusercontent.com/12893/45567964-d366e400-b820-11e8-9602-b26316f693ea.png)
