### PR TITLE
Improve Mailer Spam Ratings

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,11 @@ class ApplicationMailer < ActionMailer::Base
   default from: Rails.application.secrets.mailer_from_email
   layout 'mailer'
   
+  after_action :set_unsubscribe_header
+  
   alias_method :direct_mail, :mail
+  
+  private
   
   def mail options={}
     raise "Do not use the mail method directly, use mail_subscribed to prevent mailing unsubscribers."
@@ -14,5 +18,10 @@ class ApplicationMailer < ActionMailer::Base
     else
       Rails.logger.info("COULD NOT E-MAIL #{params[:to]} due to subscription preferences")
     end
+  end
+  
+  def set_unsubscribe_header
+    link = AccessToken.for(@unsubscriber).path_with_token('Unsubscribe')
+    headers['List-Unsubscribe'] = "<#{link}>"
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,7 +1,5 @@
 class CandidateMailer < ApplicationMailer
   add_template_helper(ApplicationHelper)
-  
-  after_action :set_unsubscribe_header
 
   def respond_to_invitation
     set_objects
@@ -33,10 +31,6 @@ class CandidateMailer < ApplicationMailer
     @fellow_opp = @token.owner
     @fellow = @fellow_opp.fellow
     @opportunity = @fellow_opp.opportunity
-  end
-  
-  def set_unsubscribe_header
-    link = AccessToken.for(@fellow).path_with_token('Unsubscribe')
-    headers['List-Unsubscribe'] = "<#{link}>"
+    @unsubscriber = @fellow
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,5 +1,7 @@
 class CandidateMailer < ApplicationMailer
   add_template_helper(ApplicationHelper)
+  
+  after_action :set_unsubscribe_header
 
   def respond_to_invitation
     set_objects
@@ -31,5 +33,10 @@ class CandidateMailer < ApplicationMailer
     @fellow_opp = @token.owner
     @fellow = @fellow_opp.fellow
     @opportunity = @fellow_opp.opportunity
+  end
+  
+  def set_unsubscribe_header
+    link = AccessToken.for(@fellow).path_with_token('Unsubscribe')
+    headers['List-Unsubscribe'] = "<#{link}>"
   end
 end

--- a/app/mailers/fellow_mailer.rb
+++ b/app/mailers/fellow_mailer.rb
@@ -1,19 +1,11 @@
 class FellowMailer < ApplicationMailer
   add_template_helper(ApplicationHelper)
   
-  after_action :set_unsubscribe_header
-
   def profile
     @token = params[:access_token]
     @fellow = @token.owner
+    @unsubscriber = @fellow
     
     mail_subscribed(@fellow.receive_opportunities, to: @fellow.contact.email, subject: "#{@fellow.first_name} - Please update your profile")
-  end
-  
-  private
-  
-  def set_unsubscribe_header
-    link = AccessToken.for(@fellow).path_with_token('Unsubscribe')
-    headers['List-Unsubscribe'] = "<#{link}>"
   end
 end

--- a/app/mailers/fellow_mailer.rb
+++ b/app/mailers/fellow_mailer.rb
@@ -1,11 +1,19 @@
 class FellowMailer < ApplicationMailer
   add_template_helper(ApplicationHelper)
+  
+  after_action :set_unsubscribe_header
 
   def profile
     @token = params[:access_token]
     @fellow = @token.owner
     
     mail_subscribed(@fellow.receive_opportunities, to: @fellow.contact.email, subject: "#{@fellow.first_name} - Please update your profile")
-
+  end
+  
+  private
+  
+  def set_unsubscribe_header
+    link = AccessToken.for(@fellow).path_with_token('Unsubscribe')
+    headers['List-Unsubscribe'] = "<#{link}>"
   end
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -101,8 +101,12 @@
     
     <div class="unsubscribe">
       <hr>
-      <%= link_to_unsubscribe(@fellow) %>
-      from notifications about future opportunities.
-    </p>
+      
+      <p>
+        We respect your time and attention.
+        <%= link_to_unsubscribe(@fellow) %>
+        from notifications about future opportunities.
+      </p>
+    </div>
   </body>
 </html>

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it { expect(mail.subject).to eq(subject) }
       it { expect(mail.to).to include(email) }
       it { expect(mail.from).to include(Rails.application.secrets.mailer_from_email) }
+      it { expect(header('List-Unsubscribe')).to match(%r!^<http://localhost:3011/fellow/profile/unsubscribe\?token=[0-9a-f]{16}>$!) }
     end
     
     def expect_content content
@@ -44,6 +45,10 @@ RSpec.describe CandidateMailer, type: :mailer do
         end
       end
     end
+  end
+  
+  def header name
+    mail.header_fields.detect{|h| h.name == name}.value
   end
   
   describe 'respond to invitation' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it { expect(mail.subject).to eq(subject) }
       it { expect(mail.to).to include(email) }
       it { expect(mail.from).to include(Rails.application.secrets.mailer_from_email) }
-      it { expect(header('List-Unsubscribe')).to match(%r!^<http://localhost:3011/fellow/profile/unsubscribe\?token=[0-9a-f]{16}>$!) }
+      it_behaves_like 'unsubscribable'
     end
     
     def expect_content content
@@ -45,10 +45,6 @@ RSpec.describe CandidateMailer, type: :mailer do
         end
       end
     end
-  end
-  
-  def header name
-    mail.header_fields.detect{|h| h.name == name}.value
   end
   
   describe 'respond to invitation' do

--- a/spec/mailers/fellow_mailer_spec.rb
+++ b/spec/mailers/fellow_mailer_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe FellowMailer, type: :mailer do
       end
     end
   end
+  
+  def header name
+    mail.header_fields.detect{|h| h.name == name}.value
+  end
 
   describe 'profile' do
     let(:access_token) { AccessToken.for(fellow) }
@@ -27,6 +31,7 @@ RSpec.describe FellowMailer, type: :mailer do
       expect(mail.subject).to eq("#{fellow.first_name} - Please update your profile")
       expect(mail.to).to include(email)
       expect(mail.from).to include(Rails.application.secrets.mailer_from_email)
+      expect(header('List-Unsubscribe')).to match(%r!^<http://localhost:3011/fellow/profile/unsubscribe\?token=[0-9a-f]{16}>$!)
     end
     
     it "renders the body with interest links" do

--- a/spec/mailers/fellow_mailer_spec.rb
+++ b/spec/mailers/fellow_mailer_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe FellowMailer, type: :mailer do
       end
     end
   end
-  
-  def header name
-    mail.header_fields.detect{|h| h.name == name}.value
-  end
 
   describe 'profile' do
     let(:access_token) { AccessToken.for(fellow) }
@@ -31,8 +27,9 @@ RSpec.describe FellowMailer, type: :mailer do
       expect(mail.subject).to eq("#{fellow.first_name} - Please update your profile")
       expect(mail.to).to include(email)
       expect(mail.from).to include(Rails.application.secrets.mailer_from_email)
-      expect(header('List-Unsubscribe')).to match(%r!^<http://localhost:3011/fellow/profile/unsubscribe\?token=[0-9a-f]{16}>$!)
     end
+    
+    it_behaves_like 'unsubscribable'
     
     it "renders the body with interest links" do
       body = mail.body.encoded

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -34,3 +34,11 @@ shared_examples_for "valid url" do |attribute, options={}|
   end
 end
 
+shared_examples_for "unsubscribable" do
+  def header name
+    field = mail.header_fields.detect{|h| h.name == name}
+    field ? field.value : nil
+  end
+
+  it { expect(header('List-Unsubscribe')).to match(%r!^<http://localhost:3011/fellow/profile/unsubscribe\?token=[0-9a-f]{16}>$!) }
+end


### PR DESCRIPTION
Two improvements:

* add 'List-Unsubscribe' header, across the board for all e-mails from MCM
* update e-mail footer to prevent violation of the REMOVE_BEFORE_LINK spamassassin rule. This rule doesn't like "no thanks" style text immediately preceding a url, but our legitimate "not interested" buttons were triggering this rule. Added "We respect your time and attention" text between the 'not interested' button and the 'unsubscribe' link.

No screencap for these backend changes, but the screenshots below show that the rule is no longer being triggered. I cheated a little, and sent these as a regular e-mail from my laptop, since I can't send e-mails through the app locally. But it works well enough to test this specific rule.

<img width="969" alt="initial-e-mail" src="https://user-images.githubusercontent.com/12893/45579880-f610f100-b850-11e8-9c74-8a808fca6cc1.png">

<img width="963" alt="autonag-mail" src="https://user-images.githubusercontent.com/12893/45579881-f9a47800-b850-11e8-9485-5e38225a2203.png">

![20180915c-specs](https://user-images.githubusercontent.com/12893/45579894-1476ec80-b851-11e8-89fa-c30b028f4b0b.png)
