### PR TITLE
Backfill fellow career steps

### DIFF
--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -207,6 +207,8 @@ class Fellow < ApplicationRecord
   end
   
   def generate_career_steps
+    return unless career_steps.empty?
+
     YAML.load(File.read("#{Rails.root}/config/career_steps.yml")).each_with_index do |step, position|
       career_steps.create position: position, name: step['name'], description: step['description']
     end

--- a/db/migrate/20180917143940_backfill_fellow_career_steps.rb
+++ b/db/migrate/20180917143940_backfill_fellow_career_steps.rb
@@ -1,0 +1,10 @@
+class BackfillFellowCareerSteps < ActiveRecord::Migration[5.2]
+  def change
+    Fellow.all.each do |fellow|
+      fellow.send(:generate_career_steps)
+      print '.'; $stdout.flush
+    end
+    
+    puts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_13_173914) do
+ActiveRecord::Schema.define(version: 2018_09_17_143940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/fellow_spec.rb
+++ b/spec/models/fellow_spec.rb
@@ -392,6 +392,14 @@ RSpec.describe Fellow, type: :model do
     it { expect(subject[11].position).to eq(11) }
     it { expect(subject[11].name).to eq('employers') }
     it { expect(subject[11].description).to eq("I've made a shortlist of positions and/or employers") }
+    
+    it "does not generate steps when they already exist" do
+      subject
+      
+      expect {
+        fellow.send(:generate_career_steps)
+      }.to change{fellow.reload.career_steps.count}.by(0)
+    end
   end
   
   describe '#completed_career_steps' do


### PR DESCRIPTION
Fellows who existed before career steps were added to the app, don't have a list of career steps. Updated the 'generate_career_steps' method to only run when a fellow's career steps are empty, then created a migration to run it for all existing fellows. No screencap for this backend task.

![20180917-backfill-specs](https://user-images.githubusercontent.com/12893/45630732-e5ce6100-ba5e-11e8-938e-14b812586b09.png)
