### PR TITLE
Spam improve text mailers

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -560,3 +560,29 @@ span.burden {
     width: 672px;
   }
 }
+
+.response-links li {
+  display: inline-block;
+  margin-right: 0.75em;
+}
+
+ul.response-links {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+ul.response-links li {
+  padding: 10px 0;
+}
+
+.response-links .button {
+  background: #999;
+}
+
+.response-links .yes .button {
+  background: green;
+}
+
+.response-links .yes .button:hover {
+  background: darkgreen;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
   end
   
   def interpolate string
-    ERB.new(string || '').result(binding)
+    ERB.new(string || '').result(binding).html_safe
   end
   
   def split_list list

--- a/app/views/candidate_mailer/notify.text.erb
+++ b/app/views/candidate_mailer/notify.text.erb
@@ -18,10 +18,5 @@
   <% end -%>
 <% end -%>
 
-<% if @content['links'] -%>
-  <% @content['links'].each do |update, label| -%>
-<%= label %>:
-<%= @token.path_with_token('status', from: @opportunity_stage.name, update: update) %>
-
-  <% end -%>
-<% end -%>
+Update us on your progress:
+<%= @token.path_with_token('view') %>

--- a/app/views/candidate_mailer/respond_to_invitation.text.erb
+++ b/app/views/candidate_mailer/respond_to_invitation.text.erb
@@ -5,8 +5,4 @@
 
 Please let us know if you're interested in this opportunity:
 
-Interested:
-<%= @token.path_with_token('status', from: 'respond to invitation', update: 'research employer') %>
-
-Not Interested:
-<%= @token.path_with_token('status', from: 'respond to invitation', update: 'fellow declined') %>
+<%= @token.path_with_token('view') %>

--- a/app/views/fellow/opportunities/show.html.erb
+++ b/app/views/fellow/opportunities/show.html.erb
@@ -13,77 +13,62 @@
 </p>
 <%= render 'admin/industries/list', object: @candidate.opportunity %>
 <%= render 'admin/interests/list', object: @candidate.opportunity %>
-<h2>Where am I in the process?</h2>
-<p><strong>Note:</strong> You're not expected to do everything below in one go. If you take a break we'll simply send you a helpful reminder so you can pick up where you left off.</p>
-<table class="opportunity-stages">
-  <thead>
-    <th class="phase">Phase</th>
-    <th class="recommended-action">Recommended Action</th>
-  </thead>
+
+<% if @candidate.stage == 'respond to invitation' %>
+  <h2>Are you Interested in This Opportunity?</h2>
   
-  <tbody>
-    <% completion = 'completed' %>
+  <ul class="response-links">
+    <li class="yes"><%= button_to_status_update 'respond to invitation', 'research employer', 'Interested' %></li>
+    <li class="no-longer-interested"><%= button_to_status_update 'respond to invitation', 'fellow declined', 'Not Interested' %></li>
+  </ul>
+<% else %>
+  <h2>Where am I in the process?</h2>
 
-    <% ['Apply', 'Interview', 'Offer'].each do |phase| %>
-      <% phase_content = @content.select{|k,v| v['phase'] == phase} %>
+  <p><strong>Note:</strong> You're not expected to do everything below in one go. If you take a break we'll simply send you a helpful reminder so you can pick up where you left off.</p>
 
-      <% phase_content.each do |stage_name, content| %>
-        <tr>
-          <% if content['phase_position'].to_i == 1 %>
-            <td class="phase phase-<%= phase.downcase %>" rowspan="<%= phase_content.size %>"><h2><%= phase %></h2></td>
-          <% end %>
+  <table class="opportunity-stages">
+    <thead>
+      <th class="phase">Phase</th>
+      <th class="recommended-action">Recommended Action</th>
+    </thead>
+  
+    <tbody>
+      <% completion = 'completed' %>
 
-          <% if stage_name == @candidate.stage # Active Stage %>
-            <% completion = 'not-completed' %> 
+      <% ['Apply', 'Interview', 'Offer'].each do |phase| %>
+        <% phase_content = @content.select{|k,v| v['phase'] == phase} %>
 
-            <td class="stage active-stage phase-<%= phase.downcase %>">
-              <% if flash[:stage_notice] %>
-                <div id="stage-notice"><%= interpolate(flash[:stage_notice]) %></div>
-              <% end %>
-              
-              <h3>
-                <%= content['phase_position'] %>. <%= content['title'] %>
-              </h3>
-              <% if content['burden'] %>
-                  <p class="burden">About <%= interpolate(content['burden']) %></p>
+        <% phase_content.each do |stage_name, content| %>
+          <tr>
+            <% if content['phase_position'].to_i == 1 %>
+              <td class="phase phase-<%= phase.downcase %>" rowspan="<%= phase_content.size %>"><h2><%= phase %></h2></td>
+            <% end %>
+
+            <% if stage_name == @candidate.stage # Active Stage %>
+              <% completion = 'not-completed' %> 
+
+              <td class="stage active-stage phase-<%= phase.downcase %>">
+                <% if flash[:stage_notice] %>
+                  <div id="stage-notice"><%= interpolate(flash[:stage_notice]) %></div>
                 <% end %>
-              <% if content['links'] %>
-                <h4 class="question"><%= interpolate(content['question']) %></h4>     
-                <ul class="response-links">
-                  <% content['links'].each do |update, label| %>
-                    <li><%= link_to_status_update update, label %></li>
-                  <% end %>
-                </ul>
-              <% end %>
-          
-              <% if content['tips'] %>
-                <h4 class="tips-toggle">How to do this like a pro</h4>
-                <div class="tips">
-                  <% if content['tips']['header'] %>
-                    <p><%= interpolate(content['tips']['header']) %></p>
-                  <% end %>
-                  <% if content['tips']['list'] %>
-                    <ul>
-                      <% content['tips']['list'].each do |tip| %>
-                        <li><%= interpolate(tip) %></li>
-                      <% end %>
-                    </ul>
-                  <% end %>
-                </div>
-              <% end %>
-            </td>
-
-          <% else # Not the active Stage %>
-            <td class="stage <%= completion %> phase-<%= phase.downcase %> inactive">
-              <h4 class="toggle-next">
-                <%= content['phase_position'] %>. <%= content['title'] %>
+              
+                <h3>
+                  <%= content['phase_position'] %>. <%= content['title'] %>
+                </h3>
                 <% if content['burden'] %>
-                  <span class="burden">About <%= interpolate(content['burden']) %></span>
-                <% end %>    
-              </h4>
-              <div class="more collapsed">
-                <h5 class="question"><%= interpolate(content['question']) %></h5>     
+                    <p class="burden">About <%= interpolate(content['burden']) %></p>
+                  <% end %>
+                <% if content['links'] %>
+                  <h4 class="question"><%= interpolate(content['question']) %></h4>     
+                  <ul class="response-links">
+                    <% content['links'].each do |update, label| %>
+                      <li><%= link_to_status_update update, label %></li>
+                    <% end %>
+                  </ul>
+                <% end %>
+          
                 <% if content['tips'] %>
+                  <h4 class="tips-toggle">How to do this like a pro</h4>
                   <div class="tips">
                     <% if content['tips']['header'] %>
                       <p><%= interpolate(content['tips']['header']) %></p>
@@ -97,11 +82,38 @@
                     <% end %>
                   </div>
                 <% end %>
-              </div>
-            </td>
-          <% end %>
-        </tr>
+              </td>
+
+            <% else # Not the active Stage %>
+              <td class="stage <%= completion %> phase-<%= phase.downcase %> inactive">
+                <h4 class="toggle-next">
+                  <%= content['phase_position'] %>. <%= content['title'] %>
+                  <% if content['burden'] %>
+                    <span class="burden">About <%= interpolate(content['burden']) %></span>
+                  <% end %>    
+                </h4>
+                <div class="more collapsed">
+                  <h5 class="question"><%= interpolate(content['question']) %></h5>     
+                  <% if content['tips'] %>
+                    <div class="tips">
+                      <% if content['tips']['header'] %>
+                        <p><%= interpolate(content['tips']['header']) %></p>
+                      <% end %>
+                      <% if content['tips']['list'] %>
+                        <ul>
+                          <% content['tips']['list'].each do |tip| %>
+                            <li><%= interpolate(tip) %></li>
+                          <% end %>
+                        </ul>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
       <% end %>
-    <% end %>
-  </tbody>
-</table>
+    </tbody>
+  </table>
+<% end %>

--- a/config/opportunity_stage_content.yml
+++ b/config/opportunity_stage_content.yml
@@ -26,10 +26,10 @@ research employer:
   tips:
     header: "Look up the employer's own website (see link above) and on other sites such as:"
     list:
-      - "LinkedIn"
-      - "GlassDoor"
-      - "Better Business Bureau"
-      - "Idealist.org (for mission-driven organizations)"
+      - "<%= link_to 'LinkedIn', 'https://www.linkedin.com', target: '_blank' %>"
+      - "<%= link_to 'GlassDoor', 'https://www.glassdoor.com', target: '_blank' %>"
+      - "<%= link_to 'Better Business Bureau', 'https://www.bbb.org', target: '_blank' %>"
+      - "<%= link_to 'Idealist.org (for mission-driven organizations)', 'https://www.idealist.org', target: '_blank' %>"
   links: *default_links
   notices: *default_notices
   burden: "15 minutes"


### PR DESCRIPTION
We needed to upgrade the text version of our candidate mailers so they don't get flagged by spam filters. Ironically, filters were flagging the fact that we had a very legitimate "not interested" link. But since the text version will be read by almost nobody, we removed the individual response buttons ("interested", "not interested", etc) with a more generic button leading them to the main page for that opportunity.

**screencap:** https://vimeo.com/290575768/a45e565502

![20180918-better-text-mailers-specs](https://user-images.githubusercontent.com/12893/45716469-9b330e80-bb5c-11e8-93c3-771376b7924a.png)
