### PR TITLE
Fix remote anywhere tag mismatch

### DIFF
--- a/app/models/metro.rb
+++ b/app/models/metro.rb
@@ -45,13 +45,23 @@ class Metro < ApplicationRecord
     state_list.split('-')
   end
   
-  def all_parents
+  def all_parents existing_parents=[]
     return [] if parents.empty?
-    (parents + parents.map(&:all_parents).flatten).compact
+    
+    more_parents = parents + (parents - existing_parents).map do |p|
+      p.all_parents(existing_parents + parents)
+    end
+    
+    more_parents.flatten.compact
   end
   
-  def all_children
+  def all_children existing_children=[]
     return [] if children.empty?
-    (children + children.map(&:all_children).flatten).compact
+
+    more_children = children + (children - existing_children).map do |c|
+      c.all_children(existing_children + children)
+    end
+    
+    more_children.flatten.compact
   end
 end

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -50,7 +50,7 @@ class Opportunity < ApplicationRecord
       candidate_ids &= fellow_ids_for_industries_interests(search_params[:industries_interests])
     end
 
-    unless search_params[:metros].nil? || search_params[:metros] == ''
+    unless search_params[:metros] == ''
       candidate_ids &= fellow_ids_for_metros(search_params[:metros])
     end
 

--- a/db/migrate/20180924164740_cross_parent_anywhere_and_remote_tags.rb
+++ b/db/migrate/20180924164740_cross_parent_anywhere_and_remote_tags.rb
@@ -1,0 +1,9 @@
+class CrossParentAnywhereAndRemoteTags < ActiveRecord::Migration[5.2]
+  def change
+    remote = Metro.find_by name: 'Remote'
+    anywhere = Metro.find_by name: 'Anywhere'
+    
+    remote.children << anywhere
+    anywhere.children << remote
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_17_143940) do
+ActiveRecord::Schema.define(version: 2018_09_24_164740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -130,8 +130,11 @@ RSpec.describe Opportunity, type: :model do
     let(:industry) { create :industry }
     let(:major_parent) { create :major }
     let(:major_child) { create :major, parent: major_parent }
-    let(:metro) { create :metro }
     let(:opportunity_type) { create :opportunity_type }
+
+    let(:metro) { create :metro }
+    let(:anywhere) { create :metro, name: 'Anywhere' }
+    let(:remote) { create :metro, name: 'Remote'}
     
     def matching_industry
       opportunity.industries << industry
@@ -160,6 +163,9 @@ RSpec.describe Opportunity, type: :model do
     before do
       opportunity.opportunity_type = opportunity_type
       fellow.opportunity_types << opportunity_type
+      
+      anywhere.children = [metro, remote]
+      remote.children = [metro, anywhere]
     end
     
     describe 'with matching metro' do
@@ -264,6 +270,18 @@ RSpec.describe Opportunity, type: :model do
       
       expect(opportunity.candidates).to include(fellow)
       expect(opportunity.candidates.size).to eq(1)
+    end
+    
+    describe 'with "anywhere" opp and "remote" fellow' do
+      before do
+        fellow.metros << remote
+        opportunity.metros << anywhere
+      end
+      
+      it "matches cross-parented siblings" do
+        matching_interest
+        expect(opportunity.candidates).to include(fellow)
+      end
     end
   end
   


### PR DESCRIPTION
The "anywhere" and "remote" tags were not matching each other - so if an opportunity had "remote" listed as the location, and a fellow had "anywhere" listed, they would not match. This is because these two tags sit at the top of the location tag hierarchy, as "siblings". And siblings don't match each other, for good reason - cities are all siblings, and a fellow searching in Chicago shouldn't match an opp in Los Angeles. But the Anywhere and Remote tags are supposed to be synonyms for each other.

I wanted to avoid coming up with another type of relationship that complicated the data connections further. The solution was twofold:

* Update the recursive "all_parents" and "all_children" methods of metros to avoid infinite loops and "stack level too deep" errors when two things are each others' parents.
* Make "anywhere" and "remote" parents of each other in the database. Therefore, they are always in each others' ancestries for matching purposes.

**screencap:** https://vimeo.com/291571466/8761f372f0

![20180924-specs](https://user-images.githubusercontent.com/12893/45982870-19415a80-c020-11e8-969d-91ac3043dc5c.png)
