### PR TITLE
redirect to root path when opportunity is no longer active

### DIFF
--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -9,7 +9,10 @@ class CandidatesController < ApplicationController
       @fellow_opportunity.update_stage(update, from: params[:from])
       
       flash[:stage_notice] = notice if notice
-      redirect_to fellow_opportunity_path(@fellow_opportunity)
+
+      redirect_to @fellow_opportunity.reload.active ?
+        fellow_opportunity_path(@fellow_opportunity) :
+        root_path
     else
       fail_token_authorize!
     end

--- a/spec/controllers/candidates_controller_spec.rb
+++ b/spec/controllers/candidates_controller_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CandidatesController, type: :controller do
   let(:previous_stage) { create :opportunity_stage, name: 'offered' }
-  let(:opportunity_stage) { create :opportunity_stage, name: 'accepted' }
+  let(:opportunity_stage) { create :opportunity_stage, name: 'accepted', active_status: active_status }
+  let(:active_status) { true }
   
   let(:access_token) { create :access_token, code: code, routes: route_list }
   let(:code) { 'aaaabbbbccccdddd' }
@@ -39,9 +40,22 @@ RSpec.describe CandidatesController, type: :controller do
       expect(response).to redirect_to(new_user_session_path)
     end
     
-    it "returns http success" do
-      get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted', token: access_token.code}
-      expect(response).to redirect_to(fellow_opportunity_path(fellow_opportunity))
+    describe 'when new stage is an "active" one' do
+      let(:active_status) { true }
+    
+      it "redirects to this opportunity" do
+        get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted', token: access_token.code}
+        expect(response).to redirect_to(fellow_opportunity_path(fellow_opportunity))
+      end
+    end
+    
+    describe 'when new stage is an "inactive" one' do
+      let(:active_status) { false }
+    
+      it "redirects to fellow's home page" do
+        get :status, params: {fellow_opportunity_id: fellow_opportunity.id, update: 'accepted', token: access_token.code}
+        expect(response).to redirect_to(root_path)
+      end
     end
     
     it "updates the fellow_opportunity stage" do

--- a/spec/factories/opportunity_stages.rb
+++ b/spec/factories/opportunity_stages.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:name){|i| "Opportunity Stage #{i}"}
     sequence(:position){|i| i}
     probability ".95"
+    active_status true
   end
 end


### PR DESCRIPTION
It used to be that when a fellow clicked "not interested", "employer rejected", or other status updates that mean "this opp is no longer active", we were still taking them to the opportunity page. Now, we're directing them based on whether they're in an "active" or "inactive" stage of the opportunity. If they're in an active stage (researching employer) we direct them to the opportunity. If the opp is now inactive "I'm no longer interested" we redirect them back to their dashboard.

**screencap:** https://vimeo.com/292353628/2d7679c0cc

![20180928-redirect-inactive-opps](https://user-images.githubusercontent.com/12893/46220446-b990cb00-c30f-11e8-95d2-bf995b8edee1.png)
