### PR TITLE
Mailer BCC

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -3,7 +3,11 @@ class CandidateMailer < ApplicationMailer
 
   def respond_to_invitation
     set_objects
-    mail_subscribed(@fellow.receive_opportunities, to: @fellow.contact.email, subject: interpolate(@split.settings['subject']))
+    
+    options = {to: @fellow.contact.email, subject: interpolate(@split.settings['subject'])}
+    options.merge!(bcc: Rails.application.secrets.mailer_bcc) if Rails.application.secrets.mailer_bcc
+
+    mail_subscribed(@fellow.receive_opportunities, options)
   end
   
   def notify
@@ -12,7 +16,10 @@ class CandidateMailer < ApplicationMailer
     @opportunity_stage = OpportunityStage.find_by(name: params[:stage_name])
     @content = @opportunity_stage.content
 
-    mail_subscribed(@fellow.receive_opportunities, to: @fellow.contact.email, subject: "#{@opportunity.name}: #{@content['title']}")
+    options = {to: @fellow.contact.email, subject: "#{@opportunity.name}: #{@content['title']}"}
+    options.merge!(bcc: Rails.application.secrets.mailer_bcc) if Rails.application.secrets.mailer_bcc
+
+    mail_subscribed(@fellow.receive_opportunities, options)
   end
   
   private

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -42,6 +42,7 @@ development:
   test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
   test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>
   redis_url: <%= ENV['DEV_REDIS_URL'] %>
+  mailer_bcc: <%= ENV['MAILER_BCC'] %>
 
 test:
   smtp_server: <%= ENV['SMTP_SERVER'] %>
@@ -87,6 +88,7 @@ test:
   test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
   test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>
   redis_url: <%= ENV['TEST_REDIS_URL'] %>
+  mailer_bcc: <%= ENV['MAILER_BCC'] %>
 
 staging:
   secret_key_base: <%= ENV['RAILS_SECRET_TOKEN'] %>
@@ -131,6 +133,7 @@ staging:
   mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
   test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
   test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>
+  mailer_bcc: <%= ENV['MAILER_BCC'] %>
 
 production:
   smtp_override_recipient: <%= ENV['SMTP_OVERRIDE_RECIPIENT'] %>
@@ -175,3 +178,4 @@ production:
   mailchimp_production_list_id: <%= ENV['MAILCHIMP_PRODUCTION_LIST_ID'] %>
   test_sso_username: <%= ENV['TEST_SSO_USERNAME'] %>
   test_sso_password: <%= ENV['TEST_SSO_PASSWORD'] %>
+  mailer_bcc: <%= ENV['MAILER_BCC'] %>

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe CandidateMailer, type: :mailer do
         end
       end
     end
+    
+    def expect_bcc
+      describe 'setting bcc' do
+        before { allow(Rails.application.secrets).to receive(:mailer_bcc).and_return(mailer_bcc) }
+
+        describe 'when mailer_bcc is nil' do
+          let(:mailer_bcc) { nil }
+          it { expect(mail.bcc).to be_nil }
+        end
+        
+        describe 'when mailer_bcc is an e-mail' do
+          let(:mailer_bcc) { 'test@example.com' }
+          it { expect(mail.bcc).to include(mailer_bcc) }
+        end
+      end
+    end
   end
   
   describe 'respond to invitation' do
@@ -54,6 +70,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     expect_headers "New Opportunity"
     expect_content 'New Opportunity'
+    expect_bcc
 
     expect_status_link 'respond to invitation', 'research employer'
     expect_status_link 'respond to invitation', 'fellow decline'
@@ -70,6 +87,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Research this Employer"
       expect_content 'Have you researched'
+      expect_bcc
 
       expect_status_link 'research employer', 'next'
       expect_status_link 'research employer', 'no change'
@@ -84,6 +102,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Connect with Current Employees"
       expect_content "Have you networked"
+      expect_bcc
 
       expect_status_link 'connect with employees', 'next'
       expect_status_link 'connect with employees', 'no change'
@@ -98,6 +117,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Customize Your Application Materials"
       expect_content "Have you customized"
+      expect_bcc
 
       expect_status_link 'customize application materials', 'next'
       expect_status_link 'customize application materials', 'no change'
@@ -112,6 +132,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Submit Your Application"
       expect_content "Have you submitted"
+      expect_bcc
 
       expect_status_link 'submit application', 'next'
       expect_status_link 'submit application', 'no change'
@@ -126,6 +147,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Follow Up on Your Application"
       expect_content "Have you followed"
+      expect_bcc
 
       expect_status_link 'follow up after application', 'next'
       expect_status_link 'follow up after application', 'no change'
@@ -141,6 +163,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Schedule an Interview"
       expect_content "Have you scheduled"
+      expect_bcc
 
       expect_status_link 'schedule interview', 'next'
       expect_status_link 'schedule interview', 'no change'
@@ -156,6 +179,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Research the Interview Process"
       expect_content "Have you researched"
+      expect_bcc
 
       expect_status_link 'research interview process', 'next'
       expect_status_link 'research interview process', 'no change'
@@ -170,6 +194,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Practice for Your Interview"
       expect_content "Have you practiced"
+      expect_bcc
 
       expect_status_link 'practice for interview', 'next'
       expect_status_link 'practice for interview', 'no change'
@@ -184,6 +209,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Ace Your Interview!"
       expect_content "Have you attended"
+      expect_bcc
 
       expect_status_link 'attend interview', 'next'
       expect_status_link 'attend interview', 'no change'
@@ -198,6 +224,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Follow Up After Your Interview"
       expect_content "Have you followed"
+      expect_bcc
 
       expect_status_link 'follow up after interview', 'next'
       expect_status_link 'follow up after interview', 'no change'
@@ -213,6 +240,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Look for an Offer"
       expect_content "Have you received"
+      expect_bcc
 
       expect_status_link 'receive offer', 'next'
       expect_status_link 'receive offer', 'no change'
@@ -227,6 +255,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Consider a Counter Offer"
       expect_content "Have you submitted"
+      expect_bcc
 
       expect_status_link 'submit counter-offer', 'receive offer'
       expect_status_link 'submit counter-offer', 'no change'
@@ -241,6 +270,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       expect_headers "New Opportunity: Accept Your Offer!"
       expect_content "Have you accepted"
+      expect_bcc
 
       expect_status_link 'accept offer', 'next'
       expect_status_link 'accept offer', 'no change'

--- a/spec/secrets_spec.rb
+++ b/spec/secrets_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Application Secrets" do
+  describe 'mailer_bcc' do
+    subject { Rails.application.secrets.mailer_bcc }
+    
+    it { should_not be_nil }
+    it { should match(/.+\@.+\..+/) }
+  end
+end


### PR DESCRIPTION
Our candidate notifier e-mails will now include a bcc address if we have one configured in the environment variable MAILER_BCC.

**NOTE:** There is a test that verifies that the environment includes SOMETHING for MAILER_BCC in order to verify that it's being set properly via the secrets file. The test environment should set this environment variable, as well as staging/prod.

![20181002-mailer-bcc-specs](https://user-images.githubusercontent.com/12893/46361053-5ca85400-c632-11e8-9d99-e1b6ada66d2d.png)

<img width="451" alt="20181002-mailer-bcc-proof" src="https://user-images.githubusercontent.com/12893/46361421-3636e880-c633-11e8-8388-77c96619e900.png">
