### PR TITLE
Fellow Import Improvements

### DIFF
--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -111,7 +111,7 @@ class Admin::OpportunitiesController < ApplicationController
     params.require(:opportunity).permit(
       :_destroy,
       :name, :summary, :employer_id, :job_posting_url, :application_deadline, 
-      :inbound, :recurring, :opportunity_type_id, :region_id, :how_to_apply,
+      :inbound, :recurring, :opportunity_type_id, :region_id, :how_to_apply, :referral_email,
       :industry_tags, :interest_tags, :metro_tags, :major_tags, :industry_interest_tags,
       steps: [],
       industry_ids: [], interest_ids: [], metro_ids: [], major_ids: [], location_ids: [],

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,11 @@
+class AdminMailer < ApplicationMailer
+  add_template_helper(ApplicationHelper)
+  
+  def application_submitted
+    @fellow_opportunity = params[:fellow_opportunity]
+    @fellow = @fellow_opportunity.fellow
+    @opportunity = @fellow_opportunity.opportunity
+    
+    direct_mail(to: @opportunity.referral_email, subject: "#{@fellow.first_name} Submitted an Application")
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -21,7 +21,9 @@ class ApplicationMailer < ActionMailer::Base
   end
   
   def set_unsubscribe_header
-    link = AccessToken.for(@unsubscriber).path_with_token('Unsubscribe')
-    headers['List-Unsubscribe'] = "<#{link}>"
+    if @unsubscriber
+      link = AccessToken.for(@unsubscriber).path_with_token('Unsubscribe')
+      headers['List-Unsubscribe'] = "<#{link}>"
+    end
   end
 end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -26,9 +26,6 @@ class Cohort < ApplicationRecord
           fellow = create fellow_attributes.merge({
             contact_attributes: contact_attributes
           })
-          
-          access_token = AccessToken.for(fellow)
-          FellowMailer.with(access_token: access_token).profile.deliver_later
         end
 
         fellow.add_metro(fellow.default_metro)

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -8,6 +8,7 @@ class Cohort < ApplicationRecord
   has_many :fellows, through: :cohort_fellows do
     def create_or_update attributes
       employment_status = EmploymentStatus.order('position asc').first
+      anywhere = Metro.find_by name: 'Anywhere'
 
       contact_attributes = attributes.slice(*Contact.attribute_names.map(&:to_sym))
       cohort_fellow_attributes = attributes.slice(*CohortFellow.attribute_names.map(&:to_sym))
@@ -28,6 +29,7 @@ class Cohort < ApplicationRecord
         end
 
         fellow.add_metro(fellow.default_metro)
+        fellow.add_metro(anywhere)
 
         proxy_association.owner.cohort_fellows.find_or_create_by(fellow_id: fellow.id).update(cohort_fellow_attributes)
       rescue ActiveRecord::RecordInvalid

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -26,6 +26,9 @@ class Cohort < ApplicationRecord
           fellow = create fellow_attributes.merge({
             contact_attributes: contact_attributes
           })
+          
+          access_token = AccessToken.for(fellow)
+          FellowMailer.with(access_token: access_token).profile.deliver_later
         end
 
         fellow.add_metro(fellow.default_metro)

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -38,6 +38,7 @@ class Fellow < ApplicationRecord
   before_create :generate_key
   after_create :generate_career_steps
   after_create :select_all_opportunity_types
+  after_create :send_profile_mailer
   after_save :attempt_fellow_match, if: :missing_user?
   
   scope :receive_opportunities, -> { where(receive_opportunities: true) }
@@ -340,5 +341,14 @@ class Fellow < ApplicationRecord
   def attempt_fellow_match
     return if contact.nil?
     FellowUserMatcher.match(contact.email)
+  end
+  
+  def access_token
+    return @access_token if defined?(@access_token)
+    @access_token = AccessToken.for(self)
+  end
+  
+  def send_profile_mailer
+    FellowMailer.with(access_token: access_token).profile.deliver_later
   end
 end

--- a/app/models/fellow_opportunity.rb
+++ b/app/models/fellow_opportunity.rb
@@ -41,6 +41,9 @@ class FellowOpportunity < ApplicationRecord
       self.update opportunity_stage: next_stage
       log next_stage.name
 
+      # handle any specific transitions from one state to another
+      transition(options[:from], next_stage.name)
+
     when 'skip'
       next_stage = next_opportunity_stage(options[:from])
 
@@ -72,6 +75,13 @@ class FellowOpportunity < ApplicationRecord
   end
   
   private
+  
+  def transition from, to
+    if from == 'submit application'
+      AdminMailer.with(fellow_opportunity: self).application_submitted.deliver_later
+    end
+    
+  end
   
   def next_opportunity_stage from=nil
     position = if from

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :referral_email, 'Referral Contact E-mail' %>
+    <%= form.text_field :referral_email %>
+  </div>
+
+  <div class="field">
     <%= form.label :opportunity_type_id, 'Opportunity Type' %>
     <%= form.collection_select(:opportunity_type_id, OpportunityType.order(position: :asc), :id, :name) %>
   </div>

--- a/app/views/admin_mailer/application_submitted.html.erb
+++ b/app/views/admin_mailer/application_submitted.html.erb
@@ -1,0 +1,1 @@
+<p><%= @fellow.full_name%> has submitted an application for <%= link_to @opportunity.name, admin_opportunity_url(@opportunity) %>!</p>

--- a/app/views/admin_mailer/application_submitted.html.erb
+++ b/app/views/admin_mailer/application_submitted.html.erb
@@ -1,1 +1,5 @@
-<p><%= @fellow.full_name%> has submitted an application for <%= link_to @opportunity.name, admin_opportunity_url(@opportunity) %>!</p>
+<p>
+  <%= link_to @fellow.full_name, admin_fellow_url(@fellow) %>
+  has submitted an application for 
+  <%= link_to @opportunity.name, admin_opportunity_url(@opportunity) %>!
+</p>

--- a/app/views/admin_mailer/application_submitted.text.erb
+++ b/app/views/admin_mailer/application_submitted.text.erb
@@ -1,0 +1,3 @@
+<%= @fellow.full_name %> has submitted an application for <%= @opportunity.name %>:
+
+<%= admin_opportunity_url(@opportunity) %>

--- a/app/views/fellow/opportunities/show.html.erb
+++ b/app/views/fellow/opportunities/show.html.erb
@@ -9,6 +9,12 @@
       <td><%= render('admin/industries/list', object: @candidate.opportunity) unless @candidate.opportunity.industries.empty? %></td>
       <td><%= render('admin/interests/list', object: @candidate.opportunity) unless @candidate.opportunity.interests.empty? %></td>
     </tr>
+    <% unless @candidate.opportunity.referral_email.blank? %>
+      <tr>
+        <th>Referral Contact E-mail:</th>
+        <td><%= link_to @candidate.opportunity.referral_email, "mailto:#{@candidate.opportunity.referral_email}" %></td>
+      </tr>
+    <% end %>
     <tr>
       <th>How to Apply:</th>
       <td><%= @candidate.opportunity.how_to_apply %></td>

--- a/db/migrate/20181011202947_add_referral_contact_to_opportunities.rb
+++ b/db/migrate/20181011202947_add_referral_contact_to_opportunities.rb
@@ -1,0 +1,5 @@
+class AddReferralContactToOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :referral_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_04_214750) do
+ActiveRecord::Schema.define(version: 2018_10_11_202947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -372,6 +372,7 @@ ActiveRecord::Schema.define(version: 2018_10_04_214750) do
     t.boolean "published", default: false
     t.text "how_to_apply"
     t.integer "priority", default: 1000
+    t.string "referral_email"
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
       
         expect(opportunity.how_to_apply).to eq("Just Try It!")
       end
+      
+      it "sets the referral e-mail" do
+        opportunity = create :opportunity
+        put :update, params: {id: opportunity.to_param, opportunity: new_attributes.merge(referral_email: 'bob@example.com')}, session: valid_session
+        opportunity.reload
+      
+        expect(opportunity.referral_email).to eq('bob@example.com')
+      end
     end
 
     context "with invalid params" do

--- a/spec/features/home_views_spec.rb
+++ b/spec/features/home_views_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "HomeViews", type: :feature do
     end
     
     scenario "Viewing the homepage", js: true do
-      expect(page).to have_content(/Career Dashboard/i)
+      expect(page).to have_content(/Job Hunter/i)
     end
   end
 end

--- a/spec/features/opportunities_views_spec.rb
+++ b/spec/features/opportunities_views_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "OpportunityViews", type: :feature do
     fill_in 'Phone', with: contact_attributes[:phone]
     fill_in 'Email', with: contact_attributes[:email]
     fill_in 'Url', with: contact_attributes[:url]
-    fill_in 'Job Posting URL', with: opportunity_attributes[:job_posting_url]
+    fill_in 'opportunity[job_posting_url]', with: opportunity_attributes[:job_posting_url]
     
     expect_list_link_for 'industries/interests', link: 'full list', within: '#interests-collection'
     expect_list_link_for :metro_areas, link: 'full list', within: '#metros-collection'

--- a/spec/lib/candidate_notifier_spec.rb
+++ b/spec/lib/candidate_notifier_spec.rb
@@ -42,9 +42,11 @@ RSpec.describe CandidateNotifier do
     let(:opportunity_stage) { create :opportunity_stage, name: stage_name}
     let(:stage_name) { 'research employer' }
     let(:active) { true }
+    let(:delayed_job_count) { Delayed::Job.count }
     
     before do
       access_token 
+      delayed_job_count
       CandidateNotifier.send_notifications
     end
     
@@ -64,7 +66,7 @@ RSpec.describe CandidateNotifier do
       let(:last_contact_at) { (CandidateNotifier::MAILER_FREQUENCY - 1).hours.ago }
       
       it 'doesn\'t notify the candidate' do
-        expect(Delayed::Job.where(queue: 'mailers').count).to eq(0)
+        expect(Delayed::Job.where(queue: 'mailers').count).to eq(delayed_job_count)
       end
       
       it "DOES NOT update the last_contact_at field" do
@@ -90,7 +92,7 @@ RSpec.describe CandidateNotifier do
       let(:active) { false }
       
       it 'doesn\'t notify the candidate' do
-        expect(Delayed::Job.where(queue: 'mailers').count).to eq(0)
+        expect(Delayed::Job.where(queue: 'mailers').count).to eq(delayed_job_count)
       end
 
       it "DOES NOT update the last_contact_at field" do

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require 'nokogiri'
+
+RSpec.describe AdminMailer, type: :mailer do
+  describe 'application submitted' do
+    let(:fellow_opportunity) { create :fellow_opportunity, opportunity: opportunity, fellow: fellow }
+    let(:fellow) { create :fellow }
+    let(:opportunity) { create :opportunity, referral_email: referral_email }
+    let(:referral_email) { 'test@example.com' }
+
+    let(:mail) { AdminMailer.with(fellow_opportunity: fellow_opportunity).application_submitted }
+    
+    it "renders the headers" do
+      expect(mail.subject).to eq("#{fellow.first_name} Submitted an Application")
+      expect(mail.to).to include(referral_email)
+      expect(mail.from).to include(Rails.application.secrets.mailer_from_email)
+    end
+    
+    it "renders the body with opportunity link" do
+      body = mail.body.encoded
+      expect(body).to include("http://localhost:3011/admin/opportunities/#{opportunity.id}")
+    end
+  end
+end

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/admin_mailer
+class AdminMailerPreview < ActionMailer::Preview
+  def application_submitted
+    fellow_opportunity = FellowOpportunity.last
+    AdminMailer.with(fellow_opportunity: fellow_opportunity).application_submitted
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe AccessToken, type: :model do
   
   describe 'validating uniqueness' do
     before do
+      allow_any_instance_of(Fellow).to receive(:send_profile_mailer).and_return(nil)
       allow_any_instance_of(AccessToken).to receive(:generate_token).and_return(nil)
       create :access_token, code: '11112222aaaabbbb'
     end


### PR DESCRIPTION
This wraps a few tasks:

* add "anywhere" tag to fellows who are imported, since the CSV doesn't include this data.
* send "update profile" e-mail automatically when a new fellow is created in the system by any means - import or manual
* add "app submitted" e-mail to staff, which goes out automatically when a candidate's status changes accordingly

@ehudtal can style the two e-mails from here, I have basic text in both of them.