### PR TITLE
Fix Broken Opportunity Views

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.4.4
 
 RUN apt-get update -yqq
 RUN apt-get install -yqq --no-install-recommends nodejs

--- a/Dockerfile.spec
+++ b/Dockerfile.spec
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.4.4
 
 RUN apt-get update -yqq
 RUN apt-get install -yqq --no-install-recommends nodejs

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -5,6 +5,7 @@ require 'taggable'
 require 'open-uri'
 
 class Fellow < ApplicationRecord
+  acts_as_paranoid
   include Taggable
 
   has_one :contact, as: :contactable, dependent: :destroy

--- a/app/models/fellow.rb
+++ b/app/models/fellow.rb
@@ -17,7 +17,7 @@ class Fellow < ApplicationRecord
   
   has_many :cohort_fellows, dependent: :destroy
   has_many :cohorts, through: :cohort_fellows
-  has_many :fellow_opportunities
+  has_many :fellow_opportunities, dependent: :destroy
   has_many :career_steps
   
   has_and_belongs_to_many :opportunity_types

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -10,7 +10,7 @@ class Opportunity < ApplicationRecord
   has_many :tasks, as: :taskable, dependent: :destroy
   accepts_nested_attributes_for :tasks, reject_if: :all_blank, allow_destroy: true
   
-  has_many :fellow_opportunities
+  has_many :fellow_opportunities, dependent: :destroy
   has_many :fellows, through: :fellow_opportunities
   
   taggable :industries, :interests, :majors, :industry_interests, :metros

--- a/db/migrate/20181025132014_add_deleted_at_to_fellows.rb
+++ b/db/migrate/20181025132014_add_deleted_at_to_fellows.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToFellows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :fellows, :deleted_at, :datetime
+    add_index  :fellows, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_18_183158) do
+ActiveRecord::Schema.define(version: 2018_10_25_132014) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -224,6 +224,8 @@ ActiveRecord::Schema.define(version: 2018_10_18_183158) do
     t.integer "portal_course_id"
     t.integer "portal_user_id"
     t.integer "portal_resume_assignment_id"
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_fellows_on_deleted_at"
     t.index ["employment_status_id"], name: "index_fellows_on_employment_status_id"
     t.index ["key"], name: "index_fellows_on_key", unique: true
     t.index ["receive_opportunities"], name: "index_fellows_on_receive_opportunities"


### PR DESCRIPTION
This was caused by missing fellow records.

* deleted orphaned fellow_opp association records in the prod db
* added soft-delete to fellows using paranoia gem
* updated fellow and opp models so deleting the record deletes the fellow_opportunity association record as well.

![20181025-specs-broken-opps](https://user-images.githubusercontent.com/12893/47503866-b286ab00-d830-11e8-9d10-7975b30fd77d.png)
