### PR TITLE
MCM Export Fixes

### DIFF
--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -5,6 +5,8 @@
 # tagsInput jQuery plugin: https://github.com/underovsky/jquery-tagsinput-revisited
 
 $(document).on "turbolinks:load",  ->
+  lastReferralValue = ''
+  
   enableTagChecklistToggle = (name, listUrl, placeholder) ->
     element = $("#opportunity_#{name}_tags")
     
@@ -133,7 +135,19 @@ $(document).on "turbolinks:load",  ->
     $('input.location[type="checkbox"]').change (event) ->
       if (this.checked)
         add_metro_tag($(this).data('zip'))
+        
+  reset_referral_contact = () ->
+    if $('#should_refer').prop('checked')
+      $('#referral_input').removeClass('form-disabled')
 
+      if lastReferralValue.length > 0
+        $('#referral_input input').val(lastReferralValue)
+    else
+      $('#referral_input').addClass('form-disabled')
+      
+      lastReferralValue = $('#referral_input input').val()
+      $('#referral_input input').val('')
+ 
   $('a.new_location').click (event) ->
     event.preventDefault()
 
@@ -146,8 +160,11 @@ $(document).on "turbolinks:load",  ->
   $('.toggle-next').click (e) ->
     e.preventDefault();
     $(this).next().toggleClass('collapsed');
-
+    
+  $('#should_refer').click (e) ->
+    reset_referral_contact()
 
   reset_datepicker()
   reset_removeable()
   reset_zip_match()
+  reset_referral_contact()

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -680,3 +680,7 @@ ul.response-links li {
     width: 672px;
   }
 }
+
+.form-disabled {
+  display: none;
+}

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -97,7 +97,7 @@ class Admin::OpportunitiesController < ApplicationController
   end
   
   def unpaginated_opportunities
-    (@employer ? @employer.opportunities : Opportunity).where(id: params[:export_ids]).prioritized.sort_by{|o| o.region.position}
+    (@employer ? @employer.opportunities : Opportunity).where(id: params[:export_ids]).prioritized.sort_by{|o| o.application_deadline || 10.years.from_now}
   end
   
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -13,7 +13,6 @@ class Admin::OpportunitiesController < ApplicationController
     respond_to do |format|
       format.csv do
         @opportunities = unpaginated_opportunities
-        Rails.logger.info("OPPS: #{@opportunities.inspect}")
         Opportunity.where(id: @opportunities.map(&:id)).update_all(published: true)
     
         headers['Content-Disposition'] = "attachment; filename=\"opportunities.csv\""

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -13,7 +13,7 @@ class Admin::OpportunitiesController < ApplicationController
     respond_to do |format|
       format.csv do
         @opportunities = unpaginated_opportunities
-        Opportunity.where(id: @opportunities.map(&:id)).update_all(published: true)
+        @opportunities.each(&:publish!)
     
         headers['Content-Disposition'] = "attachment; filename=\"opportunities.csv\""
         headers['Content-Type'] ||= 'text/csv'

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -30,7 +30,7 @@ class Opportunity < ApplicationRecord
   
   class << self
     def csv_headers
-      ['Region', 'Employer', 'Position', 'Type', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
+      ['Region', 'Employer', 'Position', 'Type', 'Referral Contact', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
     end
   end
   
@@ -178,6 +178,7 @@ class Opportunity < ApplicationRecord
         employer.name,
         name,
         opportunity_type.name,
+        referral_email,
         primary_city_state,
         job_posting_url,
         (employer.employer_partner ? 'yes' : 'no'),
@@ -231,6 +232,10 @@ class Opportunity < ApplicationRecord
     value += 10 if published?
     
     value
+  end
+  
+  def publish!
+    update published: true
   end
   
   def unpublish!

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -184,7 +184,7 @@ class Opportunity < ApplicationRecord
         (employer.employer_partner ? 'yes' : 'no'),
         (inbound ? 'yes' : 'no'),
         (recurring ? 'yes' : 'no'),
-        (interests + industries + majors).map(&:name).uniq.sort.join(', ')
+        (interests + industries).map(&:name).uniq.sort.join(', ')
       ]
     # rescue => e
     #   Rails.logger.info("COULD NOT EXPORT OPP #{id}: #{e.message}")

--- a/app/views/admin/opportunities/_form.html.erb
+++ b/app/views/admin/opportunities/_form.html.erb
@@ -17,7 +17,12 @@
   </div>
 
   <div class="field">
-    <%= form.label :referral_email, 'Referral Contact E-mail' %>
+    <%= label_tag 'should_refer', "Should fellows contact Braven staff for a referral?" %>
+    <%= check_box_tag 'should_refer', 1, opportunity.referral_email.present? %>
+  </div>
+
+  <div id="referral_input" class="field">
+    <%= form.label :referral_email, 'E-mail of Braven staff member' %>
     <%= form.text_field :referral_email %>
   </div>
 

--- a/db/migrate/20181108003930_update_opportunity_priorities.rb
+++ b/db/migrate/20181108003930_update_opportunity_priorities.rb
@@ -1,0 +1,8 @@
+class UpdateOpportunityPriorities < ActiveRecord::Migration[5.2]
+  def change
+    # Re-save all opportunities, triggering the set_priority callback.
+    # This is necessary because we weren't properly re-setting priority
+    # when opps were being published via CSV export.
+    Opportunity.all.each(&:save)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_132014) do
+ActiveRecord::Schema.define(version: 2018_11_08_003930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/admin/opportunities_controller_spec.rb
+++ b/spec/controllers/admin/opportunities_controller_spec.rb
@@ -109,6 +109,16 @@ RSpec.describe Admin::OpportunitiesController, type: :controller do
       post :export, params: {format: 'csv'}, session: valid_session
       expect(response).to be_successful
     end
+    
+    it "marks opportunities as publishd" do
+      opportunity = create :opportunity, published: false
+      
+      post :export, params: {export_ids: [opportunity.id], format: 'csv'}, session: valid_session
+      opportunity.reload
+      
+      expect(opportunity).to be_published
+      expect(opportunity.priority).to eq(opportunity.calculated_priority)
+    end
   end
 
   describe "GET #show" do

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe Opportunity, type: :model do
     it { expect(subject[7]).to eq('yes') }
     it { expect(subject[8]).to eq('no') }
     it { expect(subject[9]).to eq('yes') }
-    it { expect(subject[10]).to eq("Industry, Interest, Major") }
+    it { expect(subject[10]).to eq("Industry, Interest") }
   end
   
   describe '#priority' do

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Opportunity, type: :model do
   
   describe '#csv_headers' do
     subject { Opportunity.csv_headers }
-    it { should eq(['Region', 'Employer', 'Position', 'Type', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests'])}
+    it { should eq(['Region', 'Employer', 'Position', 'Type', 'Referral Contact', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests'])}
   end
   
   ##################
@@ -353,7 +353,7 @@ RSpec.describe Opportunity, type: :model do
   
   describe '#csv_fields' do
     let(:employer) { create :employer, employer_partner: true}
-    let(:opportunity) { create :opportunity, employer: employer, inbound: false, recurring: true, job_posting_url: 'http://example.com', name: 'CSV Opp' }
+    let(:opportunity) { create :opportunity, employer: employer, inbound: false, recurring: true, job_posting_url: 'http://example.com', name: 'CSV Opp', referral_email: 'test@example.com' }
 
     let(:fellow) { create :fellow }
     let(:interest) { create :interest, name: 'Interest' }
@@ -380,12 +380,13 @@ RSpec.describe Opportunity, type: :model do
     it { expect(subject[1]).to eq(opportunity.employer.name) }
     it { expect(subject[2]).to eq(opportunity.name) }
     it { expect(subject[3]).to eq(opportunity.opportunity_type.name) }
-    it { expect(subject[4]).to eq('Omaha, NE') }
-    it { expect(subject[5]).to eq(opportunity.job_posting_url) }
-    it { expect(subject[6]).to eq('yes') }
-    it { expect(subject[7]).to eq('no') }
-    it { expect(subject[8]).to eq('yes') }
-    it { expect(subject[9]).to eq("Industry, Interest, Major") }
+    it { expect(subject[4]).to eq('test@example.com') }
+    it { expect(subject[5]).to eq('Omaha, NE') }
+    it { expect(subject[6]).to eq(opportunity.job_posting_url) }
+    it { expect(subject[7]).to eq('yes') }
+    it { expect(subject[8]).to eq('no') }
+    it { expect(subject[9]).to eq('yes') }
+    it { expect(subject[10]).to eq("Industry, Interest, Major") }
   end
   
   describe '#priority' do
@@ -488,6 +489,20 @@ RSpec.describe Opportunity, type: :model do
       describe 'when none are true' do
         it { should eq(6) }
       end
+    end
+  end
+  
+  describe '#publish!' do
+    subject { opportunity.publish!; opportunity.reload.published }
+    
+    describe 'when opp is already published' do
+      let(:opportunity) { create :opportunity, published: true }
+      it { should eq(true) }
+    end
+
+    describe 'when opp is unpublished' do
+      let(:opportunity) { create :opportunity, published: false }
+      it { should eq(true) }
     end
   end
   


### PR DESCRIPTION
* Update an opportunity's priority rating when it is published. This was being skipped, because we were doing an 'update_all' on the published records, which skips the callback that updates priority.
* Factor deadline into sorting, with unpublished opps getting top priority.
* Remove majors from list of interests for the CSV export.
* Clarify referral contact field in opp forms. Now asking if fellows should be referred with a checkbox first, then showing/hiding the referral contact field accordingly.

**screencap:** https://vimeo.com/299654968/e114935492

![20181108-referral-contacts-specs](https://user-images.githubusercontent.com/12893/48201654-67888f80-e328-11e8-847e-046a633184ff.png)
