### PR TITLE
Adding primary id columns to join tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ log/
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# ignore JetBrains IDE files
+.idea/

--- a/db/migrate/20190225184601_add_primary_id_columns.rb
+++ b/db/migrate/20190225184601_add_primary_id_columns.rb
@@ -1,0 +1,22 @@
+class AddPrimaryIdColumns < ActiveRecord::Migration[5.2]
+  def change
+    tables_to_modify = %i(
+      coaches_cohorts
+      coaches_employers
+      employers_industries
+      fellows_industries
+      fellows_interests
+      fellows_majors
+      fellows_metros
+      fellows_opportunity_types
+      industries_opportunities
+      interests_opportunities
+      locations_opportunities
+      majors_opportunities
+      metro_relationships
+      metros_opportunities
+    )
+
+    tables_to_modify.each { |t| add_column t, :id, :primary_key }
+  end
+end


### PR DESCRIPTION
Several join tables were missing primary keys: https://docs.google.com/spreadsheets/d/1SOITbmTp19da0litT7VAuhm-95u97VnTzMQfZBk9PnU/edit#gid=399783078

This change adds the standard id column to these tables. Rails apparently handles setting the type to be BIGSERIAL as well so that it will auto increment.

Test plan: docker-compose exec career-mgr rspec spec/models. Also, exposed the database port in Docker so that I could use DataGrip to spot check the affected tables and their DDLs.