### PR TITLE
Opportunities Upgrade

### DIFF
--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -175,9 +175,6 @@ $(document).on "turbolinks:load",  ->
   $('.opportunity-checkbox').change (event) ->
     update_export_settings()
     
-  update_export_setting = (item) ->
-    console.log('replace with a call to an endpoint that marks this opp for export in the db ' + item.id + ', ' + $(item).is(':checked'))
-    
   checkbox_values = (selector) ->
     $(selector).map(() -> $(this).val()).get().join()
     
@@ -185,15 +182,20 @@ $(document).on "turbolinks:load",  ->
     $(selector).map(() -> label + '=' + $(this).val()).get()
 
   update_export_settings = () ->
-    console.log('updating export settings...')
-    
     exports = array_param('export_ids[]', '.opportunity-checkbox:checked')
     skips = array_param('skip_ids[]', '.opportunity-checkbox:not(:checked)')
     data = exports.concat(skips).join('&')
     
-    $.post("/admin/opportunities/mark_for_export", data)
+    $.ajax({url: "/admin/opportunities/mark_for_export", method: 'POST', data: data, dataType: 'json', success: update_queued_opportunities})
+    
+  update_queued_opportunities = (data) ->
+    $('#export-to-csv').val('Export ' + data.length + ' Opportunities to CSV')
+    
+  reset_queued_opportunities = () ->
+    $.ajax({url: '/admin/opportunities/queued', dataType: 'json', success: update_queued_opportunities})
       
   reset_datepicker()
   reset_removeable()
   reset_zip_match()
   reset_referral_contact()
+  reset_queued_opportunities()

--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -170,6 +170,29 @@ $(document).on "turbolinks:load",  ->
     else
       $('.opportunity-checkbox').prop('checked', false)
       
+    update_export_settings()
+			
+  $('.opportunity-checkbox').change (event) ->
+    update_export_settings()
+    
+  update_export_setting = (item) ->
+    console.log('replace with a call to an endpoint that marks this opp for export in the db ' + item.id + ', ' + $(item).is(':checked'))
+    
+  checkbox_values = (selector) ->
+    $(selector).map(() -> $(this).val()).get().join()
+    
+  array_param = (label, selector) ->
+    $(selector).map(() -> label + '=' + $(this).val()).get()
+
+  update_export_settings = () ->
+    console.log('updating export settings...')
+    
+    exports = array_param('export_ids[]', '.opportunity-checkbox:checked')
+    skips = array_param('skip_ids[]', '.opportunity-checkbox:not(:checked)')
+    data = exports.concat(skips).join('&')
+    
+    $.post("/admin/opportunities/mark_for_export", data)
+      
   reset_datepicker()
   reset_removeable()
   reset_zip_match()

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -707,6 +707,24 @@ input.checkbox-multiline {
   margin-right: 8px;
 }
 
+a.button-white {
+  background: white;
+  color: black;
+  border: 1px solid #ccc;
+  padding: 6px 12px;
+  font-family: DIN, "TradeGothicNo.20-CondBold", "Oswald", sans-serif;
+  text-transform: uppercase;
+  border-radius: 2px;
+  transition: background-color 0.2s ease-in-out;
+  margin-bottom: 0;
+  line-height: 1;
+  font-size: 12px;
+}
+
+a.button-white:hover {
+  background: #eee;
+  text-decoration: none;
+}
 .showpage h1 {
   margin-bottom: 0;
 }

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -33,6 +33,13 @@ class Admin::OpportunitiesController < ApplicationController
   def queued
     render json: Opportunity.ready_for_export
   end
+  
+  def unqueue
+    Opportunity.ready_for_export.update_all(export: false)
+    flash[:notice] = 'There are no more opportunties queued for export'
+
+    redirect_to admin_opportunities_path
+  end
 
   # GET /opportunities/1
   # GET /opportunities/1.json

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -1,4 +1,6 @@
 class Admin::OpportunitiesController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:mark_for_export]
+  
   before_action :authenticate_user!
   before_action :ensure_admin!
   before_action :set_employer
@@ -19,6 +21,13 @@ class Admin::OpportunitiesController < ApplicationController
         headers['Content-Type'] ||= 'text/csv'
       end
     end
+  end
+  
+  def mark_for_export
+    Opportunity.where(id: params[:export_ids]).update_all(export: true)
+    Opportunity.where(id: params[:skip_ids]).update_all(export: false)
+    
+    render plain: 'ok'
   end
 
   # GET /opportunities/1

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -131,7 +131,7 @@ class Admin::OpportunitiesController < ApplicationController
   
   # Use callbacks to share common setup or constraints between actions.
   def set_opportunity
-    @opportunity = @opportunities.find(params[:id])
+    @opportunity = Opportunity.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -1,5 +1,5 @@
 class Admin::OpportunitiesController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:mark_for_export]
+  skip_before_action :verify_authenticity_token, only: [:mark_for_export, :queued]
   
   before_action :authenticate_user!
   before_action :ensure_admin!
@@ -28,6 +28,12 @@ class Admin::OpportunitiesController < ApplicationController
     Opportunity.where(id: params[:skip_ids]).update_all(export: false)
     
     render plain: 'ok'
+  end
+  def tester; end
+  def queued
+    @opportunities = Opportunity.ready_for_export
+    
+    render json: @opportunities
   end
 
   # GET /opportunities/1

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -14,7 +14,7 @@ class Admin::OpportunitiesController < ApplicationController
   def export
     respond_to do |format|
       format.csv do
-        @opportunities = unpaginated_opportunities
+        @opportunities = exportable_opportunities
         @opportunities.each(&:publish!)
     
         headers['Content-Disposition'] = "attachment; filename=\"opportunities.csv\""
@@ -105,8 +105,8 @@ class Admin::OpportunitiesController < ApplicationController
     end
   end
   
-  def unpaginated_opportunities
-    (@employer ? @employer.opportunities : Opportunity).where(id: params[:export_ids]).prioritized.sort_by{|o| o.application_deadline || 10.years.from_now}
+  def exportable_opportunities
+    (@employer ? @employer.opportunities : Opportunity).ready_for_export.prioritized.sort_by{|o| o.application_deadline || 10.years.from_now}
   end
   
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -27,13 +27,11 @@ class Admin::OpportunitiesController < ApplicationController
     Opportunity.where(id: params[:export_ids]).update_all(export: true)
     Opportunity.where(id: params[:skip_ids]).update_all(export: false)
     
-    render plain: 'ok'
+    render json: Opportunity.ready_for_export
   end
-  def tester; end
+
   def queued
-    @opportunities = Opportunity.ready_for_export
-    
-    render json: @opportunities
+    render json: Opportunity.ready_for_export
   end
 
   # GET /opportunities/1

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -111,11 +111,16 @@ class Admin::OpportunitiesController < ApplicationController
     @employer = Employer.find(params[:employer_id]) if params[:employer_id]
     @opportunities = (@employer ? @employer.opportunities : Opportunity).active.prioritized.paginate(page: params[:page])
     
-    unless params[:region_id].blank?
-      @opportunities = if params[:region_id] == 'queued'
-        @opportunities.ready_for_export
+    if params[:region_id].blank?
+      @opportunities = @opportunities.current
+    else
+      @opportunities = case params[:region_id]
+      when 'queued'
+        @opportunities.current.ready_for_export
+      when 'expired'
+        @opportunities.expired
       else
-        @opportunities.where(region_id: params[:region_id])
+        @opportunities.current.where(region_id: params[:region_id])
       end
     end
   end

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -105,7 +105,11 @@ class Admin::OpportunitiesController < ApplicationController
     @opportunities = (@employer ? @employer.opportunities : Opportunity).active.prioritized.paginate(page: params[:page])
     
     unless params[:region_id].blank?
-      @opportunities = @opportunities.where(region_id: params[:region_id])
+      @opportunities = if params[:region_id] == 'queued'
+        @opportunities.ready_for_export
+      else
+        @opportunities.where(region_id: params[:region_id])
+      end
     end
   end
   

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -109,7 +109,7 @@ class Admin::OpportunitiesController < ApplicationController
   
   def set_employer
     @employer = Employer.find(params[:employer_id]) if params[:employer_id]
-    @opportunities = (@employer ? @employer.opportunities : Opportunity).active.prioritized.paginate(page: params[:page])
+    @opportunities = (@employer ? @employer.opportunities : Opportunity).prioritized.paginate(page: params[:page])
     
     if params[:region_id].blank?
       @opportunities = @opportunities.current
@@ -131,7 +131,7 @@ class Admin::OpportunitiesController < ApplicationController
   
   # Use callbacks to share common setup or constraints between actions.
   def set_opportunity
-    @opportunity = Opportunity.find(params[:id])
+    @opportunity = @opportunities.find(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/helpers/opportunities_helper.rb
+++ b/app/helpers/opportunities_helper.rb
@@ -17,4 +17,15 @@ module OpportunitiesHelper
       </li>
     TASK_FIELDS
   end
+  
+  def opportunity_filters
+    [
+      ['Status', [
+        ['Queued for Export', 'queued'],
+        ['Expired', 'expired']
+      ]],
+      
+      ['Region', Region.order(position: :asc).pluck(:name, :id)]
+    ]
+  end
 end

--- a/app/models/employer.rb
+++ b/app/models/employer.rb
@@ -11,6 +11,8 @@ class Employer < ApplicationRecord
   taggable :industries
   
   accepts_nested_attributes_for :industries
+  
+  scope :alphabetical, -> { order(name: :asc) }
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -28,6 +28,8 @@ class Opportunity < ApplicationRecord
   scope :active, -> { where("application_deadline >= ? or application_deadline IS NULL", Date.today) }
   scope :prioritized, -> { order(priority: :asc) }
   scope :ready_for_export, -> { where(export: true) }
+  scope :expired, -> { where("application_deadline < ?", Date.today) }
+  scope :current, -> { where("application_deadline >= ? or application_deadline is null", Date.today) }
   
   before_save :set_priority
   

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -25,11 +25,10 @@ class Opportunity < ApplicationRecord
   validates :job_posting_url, url: {ensure_protocol: true}
   validate :validate_locateable
   
-  scope :active, -> { where("application_deadline >= ? or application_deadline IS NULL", Date.today) }
   scope :prioritized, -> { order(priority: :asc) }
   scope :ready_for_export, -> { where(export: true) }
   scope :expired, -> { where("application_deadline < ?", Date.today) }
-  scope :current, -> { where("application_deadline >= ? or application_deadline is null", Date.today) }
+  scope :current, -> { where("application_deadline >= ? or application_deadline IS NULL", Date.today) }
   
   before_save :set_priority
   

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -27,6 +27,7 @@ class Opportunity < ApplicationRecord
   
   scope :active, -> { where("application_deadline >= ? or application_deadline IS NULL", Date.today) }
   scope :prioritized, -> { order(priority: :asc) }
+  scope :ready_for_export, -> { where(export: true) }
   
   before_save :set_priority
   
@@ -237,7 +238,7 @@ class Opportunity < ApplicationRecord
   end
   
   def publish!
-    update published: true
+    update published: true, export: false
   end
   
   def unpublish!

--- a/app/views/admin/employers/index.html.erb
+++ b/app/views/admin/employers/index.html.erb
@@ -2,7 +2,7 @@
 
 <table class="action-list employers">
   <tbody>
-    <% @employers.order(name: :asc).each do |employer| %>
+    <% @employers.alphabetical.each do |employer| %>
       <tr>
         <td><%= link_to employer.name, admin_employer_path(employer) %></td>
         <td><%= link_to 'Edit', edit_admin_employer_path(employer), class: 'edit' %></td>

--- a/app/views/admin/home/new_opportunity.html.erb
+++ b/app/views/admin/home/new_opportunity.html.erb
@@ -1,7 +1,7 @@
 <h1>Add New Opportunity</h1>
 <h2>Step 1: Choose an existing employer:</h2>
 <ul>  
-  <% @employers.each do |employer| %>
+  <% @employers.alphabetical.each do |employer| %>
     <li><%= link_to employer.name, new_admin_employer_opportunity_path(employer) %></li>
   <% end %>
 </ul>

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -48,6 +48,9 @@
       </tbody>
     </table>
 
-    <p><%= submit_tag 'Export to CSV', id: 'export-to-csv' %></p>
+    <p>
+      <%= submit_tag 'Export to CSV', id: 'export-to-csv' %>
+      <%= link_to 'Clear Export List', unqueue_admin_opportunities_path, class: 'button-white' %>
+    </p>
   <% end %>
 <% end %>

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -42,7 +42,7 @@
               <%= link_to 'Delete', admin_opportunity_path(opportunity), method: :delete, data: { confirm: 'Are you sure?' }, class: 'delete' %><br />
               <%= link_to('Unpublish', unpublish_admin_opportunity_path(opportunity), method: :put, class: 'edit') if opportunity.published? %>
             </td>
-            <td class="numeric"><%= check_box_tag 'export_ids[]', opportunity.id, !opportunity.published, class: 'opportunity-checkbox' %></td>
+            <td class="numeric"><%= check_box_tag 'export_ids[]', opportunity.id, opportunity.export, class: 'opportunity-checkbox' %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -48,6 +48,6 @@
       </tbody>
     </table>
 
-    <p><%= submit_tag 'Export to CSV' %></p>
+    <p><%= submit_tag 'Export to CSV', id: 'export-to-csv' %></p>
   <% end %>
 <% end %>

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -1,11 +1,11 @@
 <%= form_tag admin_opportunities_path, method: :get, id: 'opportunity-filters' do %>
-  <%= select_tag(:region_id, options_from_collection_for_select(([OpenStruct.new(id: 'queued', name: 'Queued for Export')] + Region.order(position: :asc)), :id, :name, params[:region_id]), include_blank: 'Choose a Filter')%>
+  <%= select_tag(:region_id, grouped_options_for_select(opportunity_filters, params[:region_id]), include_blank: 'Choose a Filter')%>
   
   <%= submit_tag 'filter' %>
 <% end %>
 
 <% if opportunities.empty? %>
-  <p class="empty-list">There are no opportunties to show here.</p>
+  <p class="empty-list">There are no opportunities to show here.</p>
 <% else %>
   <%= form_tag export_admin_opportunities_path(format: 'csv'), method: :post do %>
     <table class="wide">

--- a/app/views/admin/opportunities/_list.html.erb
+++ b/app/views/admin/opportunities/_list.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag admin_opportunities_path, method: :get, id: 'opportunity-filters' do %>
-  <%= select_tag(:region_id, options_from_collection_for_select(Region.order(position: :asc), :id, :name, params[:region_id]), include_blank: 'filter by region')%>
+  <%= select_tag(:region_id, options_from_collection_for_select(([OpenStruct.new(id: 'queued', name: 'Queued for Export')] + Region.order(position: :asc)), :id, :name, params[:region_id]), include_blank: 'Choose a Filter')%>
   
   <%= submit_tag 'filter' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     resources :opportunities, only: [:index] do
       collection do
         get :queued
+        get :unqueue
 
         post :mark_for_export
         post :export

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   
     resources :opportunities, only: [:index] do
       collection do
+        post :mark_for_export
         post :export
       end
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,15 +41,10 @@ Rails.application.routes.draw do
     get 'home/stats'
     get 'home/new_opportunity', as: 'new_opportunity'
 
-    resources :employers, shallow: true do
-      resources :locations
-      resources :opportunities do
-        resources :candidates, only: [:index, :create, :update, :destroy]
-      end
-    end
-  
     resources :opportunities, only: [:index] do
       collection do
+        get :queued
+
         post :mark_for_export
         post :export
       end
@@ -59,6 +54,13 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :employers, shallow: true do
+      resources :locations
+      resources :opportunities do
+        resources :candidates, only: [:index, :create, :update, :destroy]
+      end
+    end
+    
     resources :sites, shallow: true do
       resources :courses, except: [:index]
     end

--- a/db/migrate/20190316183127_add_export_boolean_to_opportunities.rb
+++ b/db/migrate/20190316183127_add_export_boolean_to_opportunities.rb
@@ -1,0 +1,6 @@
+class AddExportBooleanToOpportunities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :opportunities, :export, :boolean, default: false
+    add_index :opportunities, :export
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_16_143026) do
+ActiveRecord::Schema.define(version: 2019_03_16_183127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,14 +74,14 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["name"], name: "index_coaches_on_name", unique: true
   end
 
-  create_table "coaches_cohorts", id: false, force: :cascade do |t|
+  create_table "coaches_cohorts", force: :cascade do |t|
     t.bigint "coach_id", null: false
     t.bigint "cohort_id", null: false
     t.index ["coach_id"], name: "index_coaches_cohorts_on_coach_id"
     t.index ["cohort_id"], name: "index_coaches_cohorts_on_cohort_id"
   end
 
-  create_table "coaches_employers", id: false, force: :cascade do |t|
+  create_table "coaches_employers", force: :cascade do |t|
     t.bigint "coach_id", null: false
     t.bigint "employer_id", null: false
     t.index ["coach_id"], name: "index_coaches_employers_on_coach_id"
@@ -169,7 +169,7 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["name"], name: "index_employers_on_name", unique: true
   end
 
-  create_table "employers_industries", id: false, force: :cascade do |t|
+  create_table "employers_industries", force: :cascade do |t|
     t.bigint "industry_id", null: false
     t.bigint "employer_id", null: false
     t.index ["employer_id"], name: "index_employers_industries_on_employer_id"
@@ -232,35 +232,35 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["user_id"], name: "index_fellows_on_user_id"
   end
 
-  create_table "fellows_industries", id: false, force: :cascade do |t|
+  create_table "fellows_industries", force: :cascade do |t|
     t.bigint "fellow_id", null: false
     t.bigint "industry_id", null: false
     t.index ["fellow_id"], name: "index_fellows_industries_on_fellow_id"
     t.index ["industry_id"], name: "index_fellows_industries_on_industry_id"
   end
 
-  create_table "fellows_interests", id: false, force: :cascade do |t|
+  create_table "fellows_interests", force: :cascade do |t|
     t.bigint "fellow_id", null: false
     t.bigint "interest_id", null: false
     t.index ["fellow_id"], name: "index_fellows_interests_on_fellow_id"
     t.index ["interest_id"], name: "index_fellows_interests_on_interest_id"
   end
 
-  create_table "fellows_majors", id: false, force: :cascade do |t|
+  create_table "fellows_majors", force: :cascade do |t|
     t.bigint "fellow_id", null: false
     t.bigint "major_id", null: false
     t.index ["fellow_id", "major_id"], name: "index_fellows_majors_on_fellow_id_and_major_id"
     t.index ["major_id", "fellow_id"], name: "index_fellows_majors_on_major_id_and_fellow_id"
   end
 
-  create_table "fellows_metros", id: false, force: :cascade do |t|
+  create_table "fellows_metros", force: :cascade do |t|
     t.bigint "fellow_id", null: false
     t.bigint "metro_id", null: false
     t.index ["fellow_id"], name: "index_fellows_metros_on_fellow_id"
     t.index ["metro_id"], name: "index_fellows_metros_on_metro_id"
   end
 
-  create_table "fellows_opportunity_types", id: false, force: :cascade do |t|
+  create_table "fellows_opportunity_types", force: :cascade do |t|
     t.bigint "fellow_id", null: false
     t.bigint "opportunity_type_id", null: false
     t.index ["fellow_id"], name: "index_fellows_opportunity_types_on_fellow_id"
@@ -275,7 +275,7 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["name"], name: "index_industries_on_name", unique: true
   end
 
-  create_table "industries_opportunities", id: false, force: :cascade do |t|
+  create_table "industries_opportunities", force: :cascade do |t|
     t.bigint "industry_id", null: false
     t.bigint "opportunity_id", null: false
     t.index ["industry_id"], name: "index_industries_opportunities_on_industry_id"
@@ -290,7 +290,7 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["name"], name: "index_interests_on_name", unique: true
   end
 
-  create_table "interests_opportunities", id: false, force: :cascade do |t|
+  create_table "interests_opportunities", force: :cascade do |t|
     t.bigint "interest_id", null: false
     t.bigint "opportunity_id", null: false
     t.index ["interest_id"], name: "index_interests_opportunities_on_interest_id"
@@ -306,7 +306,7 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["locateable_id", "locateable_type"], name: "index_locations_on_locateable_id_and_locateable_type"
   end
 
-  create_table "locations_opportunities", id: false, force: :cascade do |t|
+  create_table "locations_opportunities", force: :cascade do |t|
     t.bigint "location_id", null: false
     t.bigint "opportunity_id", null: false
     t.index ["location_id"], name: "index_locations_opportunities_on_location_id"
@@ -322,14 +322,14 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["parent_id"], name: "index_majors_on_parent_id"
   end
 
-  create_table "majors_opportunities", id: false, force: :cascade do |t|
+  create_table "majors_opportunities", force: :cascade do |t|
     t.bigint "major_id", null: false
     t.bigint "opportunity_id", null: false
     t.index ["major_id", "opportunity_id"], name: "index_majors_opportunities_on_major_id_and_opportunity_id"
     t.index ["opportunity_id", "major_id"], name: "index_majors_opportunities_on_opportunity_id_and_major_id"
   end
 
-  create_table "metro_relationships", id: false, force: :cascade do |t|
+  create_table "metro_relationships", force: :cascade do |t|
     t.integer "parent_id"
     t.integer "child_id"
     t.index ["child_id"], name: "index_metro_relationships_on_child_id"
@@ -350,7 +350,7 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.index ["state"], name: "index_metros_on_state"
   end
 
-  create_table "metros_opportunities", id: false, force: :cascade do |t|
+  create_table "metros_opportunities", force: :cascade do |t|
     t.bigint "metro_id", null: false
     t.bigint "opportunity_id", null: false
     t.index ["metro_id"], name: "index_metros_opportunities_on_metro_id"
@@ -375,8 +375,10 @@ ActiveRecord::Schema.define(version: 2019_03_16_143026) do
     t.integer "priority", default: 1000
     t.string "referral_email"
     t.datetime "deleted_at"
+    t.boolean "export", default: false
     t.index ["deleted_at"], name: "index_opportunities_on_deleted_at"
     t.index ["employer_id"], name: "index_opportunities_on_employer_id"
+    t.index ["export"], name: "index_opportunities_on_export"
     t.index ["inbound"], name: "index_opportunities_on_inbound"
     t.index ["opportunity_type_id"], name: "index_opportunities_on_opportunity_type_id"
     t.index ["priority"], name: "index_opportunities_on_priority"


### PR DESCRIPTION
This PR combines a couple of admin opportunities tickets:

**Selecting Opps Across Multiple Pages for Export**
* multi-page select
* export button reflects how many opps are selected at the time
* all selections across all pages can be cleared with a button
* all selections can be viewed at once with a filter

**Viewing/Editing Expired Opps**

This is implemented as another filter available from the pulldown.

**Alphabetical Employers on New Opp Page**

This was a last minute add-on, as a stop-gap until we can implement employer search.

**screenshot:** https://cl.ly/fb7995cc0615

note: the glitch at the end of the screenshot has been fixed in this PR.