### PR TITLE
Assign admins to regions

### DIFF
--- a/app/assets/javascripts/opportunities.coffee
+++ b/app/assets/javascripts/opportunities.coffee
@@ -175,6 +175,11 @@ $(document).on "turbolinks:load",  ->
   $('.opportunity-checkbox').change (event) ->
     update_export_settings()
     
+    
+  $('#export-to-csv').click (event) ->
+    callback = -> location.reload()
+    setTimeout callback, 1000
+    
   checkbox_values = (selector) ->
     $(selector).map(() -> $(this).val()).get().join()
     

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -33,7 +33,10 @@ class Admin::OpportunitiesController < ApplicationController
   end
 
   def queued
-    render json: current_user.ready_for_export
+    respond_to do |format|
+      format.json { render json: current_user.ready_for_export }
+      format.html { redirect_to admin_opportunities_path }
+    end
   end
   
   def unqueue

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -16,6 +16,8 @@ class Admin::OpportunitiesController < ApplicationController
       format.csv do
         @opportunities = exportable_opportunities
         @opportunities.each(&:publish!)
+        
+        current_user.remove_all_exports
     
         headers['Content-Disposition'] = "attachment; filename=\"opportunities.csv\""
         headers['Content-Type'] ||= 'text/csv'

--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -1,0 +1,26 @@
+class Admin::ProfilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :ensure_admin!
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if current_user.update(admin_params)
+      redirect_to admin_profile_path, notice: 'Your profile was successfully updated.'
+    else
+      render :edit
+    end
+  end
+  
+  private
+  
+  def admin_params
+    params.require(:user).permit(
+      :first_name, :last_name, :region_id
+    )
+  end
+end

--- a/app/models/metro.rb
+++ b/app/models/metro.rb
@@ -38,6 +38,15 @@ class Metro < ApplicationRecord
     end
   end
   
+  def label
+    city, state = name.split(/,\s+/)
+
+    return name unless state
+    
+    primary_state, secondary_state = state.split('-', 2)
+    [city, primary_state].join(', ')
+  end
+  
   def states
     city, state_list = name.split(/,\s*/)
     return [] if state_list.nil?

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -44,7 +44,7 @@ class Opportunity < ApplicationRecord
   delegate :employer_partner?, to: :employer
   
   before_save :set_priority
-  after_create :queue_to_admins
+  after_create :queue_to_subscribed
   
   class << self
     def csv_headers
@@ -261,11 +261,11 @@ class Opportunity < ApplicationRecord
   
   def unpublish!
     update published: false
-    queue_to_admins
+    queue_to_subscribed
   end
   
-  def queue_to_admins
-    User.admin.each{|admin| admin.add_export_ids([self.id])}
+  def queue_to_subscribed
+    User.admin.where(region_id: region.id).each{|admin| admin.add_export_ids([self.id])}
   end
   
   def set_default_industries

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -48,7 +48,7 @@ class Opportunity < ApplicationRecord
   
   class << self
     def csv_headers
-      ['Region', 'Employer', 'Position', 'Type', 'Referral Contact', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
+      ['Region', 'Employer', 'Position', 'Type', 'Referral Contact', 'Locations', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests']
     end
   end
   
@@ -211,20 +211,15 @@ class Opportunity < ApplicationRecord
   end
   
   def primary_city_state
-    if metros.first
-      metro_name = metros.first.name
-      
-      city, state = metro_name.split(/,\s+/)
-    
-      return metro_name unless state
-      primary_state, secondary_state = state.split('-', 2)
-    
-      [city, primary_state].join(', ')
+    location_labels = if metros.empty?
+      locations.map do |location|
+        [location.contact.city, location.contact.state].join(', ')
+      end
     else
-      contact = locations.first.contact
-      
-      [contact.city, contact.state].join(', ')
+      metros.map(&:label)
     end
+    
+    location_labels.uniq.join('; ')
   end
   
   # lowest priority is best/first

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,5 +1,6 @@
 class Region < ApplicationRecord
   has_many :opportunities
+  has_many :users
   
   validates :name, :position, presence: true, uniqueness: true
   

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -4,6 +4,8 @@ class Region < ApplicationRecord
   
   validates :name, :position, presence: true, uniqueness: true
   
+  scope :by_position, -> { order(position: :asc) }
+  
   class << self
     def types
       return @types if defined?(@types)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
          
+  belongs_to :region, required: false
+         
   has_one :fellow
   
   has_many :opportunity_exports

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User < ApplicationRecord
   
   scope :admin, -> { where(is_admin: true) }
   
+  def full_name
+    [first_name, last_name].join(' ').strip
+  end
+  
   def role
     if is_admin?
       :admin

--- a/app/views/admin/profiles/_form.html.erb
+++ b/app/views/admin/profiles/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with(model: [:admin, current_user], local: true, url: admin_profile_path, html: {method: 'patch'}) do |form| %>
+  <% if current_user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(current_user.errors.count, "error") %> prohibited this profile from being saved:</h2>
+
+      <ul>
+      <% current_user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <h2 id="info-personal">Personal Info</h2>
+
+  <div class="field">
+    <%= form.label :first_name %>
+    <%= form.text_field :first_name, required: true %>
+  </div>
+
+  <div class="field">
+    <%= form.label :last_name %>
+    <%= form.text_field :last_name, required: true %>
+  </div>
+
+  <div class="field">
+    <%= form.label :region_id, 'Region' %>
+    <%= form.collection_select :region_id, Region.by_position, :id, :name, prompt: 'Select a Region' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit 'Update Profile' %>
+  </div>
+<% end %>

--- a/app/views/admin/profiles/edit.html.erb
+++ b/app/views/admin/profiles/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Update Profile</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', admin_profile_path() %>
+

--- a/app/views/admin/profiles/show.html.erb
+++ b/app/views/admin/profiles/show.html.erb
@@ -1,0 +1,19 @@
+<h1>My Profile</h1>
+
+<%= link_to 'Edit Profile', edit_admin_profile_path, class: 'edit' %>
+
+<table>
+  <tbody>
+    <tr class="name">
+      <th>Name:</th>
+      <td><%= current_user.full_name %></td>
+    </tr>
+    <tr class="region">
+      <th>Region:</th>
+      <td><%= current_user.region ? current_user.region.name : 'Unassigned' %></td>
+    </tr>
+  </tbody>
+</table>
+
+<%= link_to 'Edit Profile', edit_admin_profile_path, class: 'edit' %> | 
+<%= link_to 'Back to dashboard', root_path, class: 'back' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
               <li><%= nav_link "Interests", admin_interests_path %> (<%= Interest.count %>)</li>
               <li><%= nav_link "Sites", admin_sites_path %> (<%= Site.count %>)</li>
               <li><%= nav_link "Fellows", admin_fellows_path %> (<%= Fellow.count %>)</li>
+              <li><%= nav_link "Profile", admin_profile_path %></li>
             <% elsif current_user.is_fellow? %>
               <li><%= nav_link "Dashboard", fellow_home_welcome_path %></li>
               <li><%= nav_link "Profile", fellow_profile_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
     get 'home/stats'
     get 'home/new_opportunity', as: 'new_opportunity'
 
+    resource :profile, only: [:show, :edit, :update]
+
     resources :opportunities, only: [:index] do
       collection do
         get :queued

--- a/db/migrate/20190423231440_add_region_id_to_users.rb
+++ b/db/migrate/20190423231440_add_region_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddRegionIdToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :region_id, :integer
+    add_index :users, :region_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_30_182222) do
+ActiveRecord::Schema.define(version: 2019_04_23_231440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -484,10 +484,12 @@ ActiveRecord::Schema.define(version: 2019_03_30_182222) do
     t.datetime "updated_at", null: false
     t.boolean "is_admin", default: false
     t.boolean "is_fellow", default: false
+    t.integer "region_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["is_admin"], name: "index_users_on_is_admin"
     t.index ["is_fellow"], name: "index_users_on_is_fellow"
+    t.index ["region_id"], name: "index_users_on_region_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/controllers/admin/profiles_controller_spec.rb
+++ b/spec/controllers/admin/profiles_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ProfilesController, type: :controller do
+  render_views
+  
+  let(:user) { create :admin_user }
+  
+  before do 
+    sign_in user
+  end
+
+  let(:valid_attributes) { {first_name: 'Bob'} }
+  let(:invalid_attributes) { {name: ''} }
+  let(:valid_session) { {} }
+
+  describe "GET #show" do
+    it "returns a success response" do
+      get :show, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #edit" do
+    it "returns a success response" do
+      get :edit, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "PUT #update" do
+    context "with valid params" do
+      it "updates the first name" do
+        new_first_name = "#{user.first_name}x"
+        put :update, params: {user: {first_name: new_first_name}}, session: valid_session
+        user.reload
+        
+        expect(user.first_name).to eq(new_first_name)
+      end
+
+      it "updates the last name" do
+        new_last_name = "#{user.last_name}x"
+        put :update, params: {user: {last_name: new_last_name}}, session: valid_session
+        user.reload
+        
+        expect(user.last_name).to eq(new_last_name)
+      end
+
+      it "updates the region" do
+        region = create :region
+        put :update, params: {user: {region_id: region.id}}, session: valid_session
+        user.reload
+        
+        expect(user.region).to eq(region)
+      end
+    end
+
+    # no invalid params at this time.
+    # context "with invalid params" do
+    #   it "returns a success response (i.e. to display the 'edit' template)" do
+    #     put :update, params: {name: 'something'}, session: valid_session
+    #     expect(response).to be_successful
+    #   end
+    # end
+  end
+end

--- a/spec/models/opportunity_spec.rb
+++ b/spec/models/opportunity_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Opportunity, type: :model do
   
   describe '#csv_headers' do
     subject { Opportunity.csv_headers }
-    it { should eq(['Region', 'Employer', 'Position', 'Type', 'Referral Contact', 'Location', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests'])}
+    it { should eq(['Region', 'Employer', 'Position', 'Type', 'Referral Contact', 'Locations', 'Link', 'Employer Partner', 'Inbound', 'Recurring', 'Interests'])}
   end
   
   ##################

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Region, type: :model do
   ##############
 
   it { should have_many :opportunities }
+  it { should have_many :users }
   
   #############
   # Validations

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,4 +113,25 @@ RSpec.describe User, type: :model do
       it { expect(subject).to eq(nil) }
     end
   end
+  
+  describe '#full_name' do
+    let(:first_name) { 'Bob' }
+    let(:last_name) { 'Smith' }
+    
+    subject { build(:user, first_name: first_name, last_name: last_name).full_name }
+    
+    describe 'when first and last name exist' do
+      it { should eq('Bob Smith')}
+    end
+    
+    describe 'when first name is missing' do
+      let(:first_name) { nil }
+      it { should eq('Smith') }
+    end
+    
+    describe 'when last name is missing' do
+      let(:last_name) { nil }
+      it { should eq('Bob') }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User, type: :model do
   it { should have_one :fellow }
   
   it { should have_many :opportunity_exports }
+  it { should belong_to :region }
 
   #############
   # Validations


### PR DESCRIPTION
In this PR, we're narrowing the scope of what gets automatically added to an admin's opportunity export queue. Admins can subscribe (assign themselves) to a given region on their newly created profile page. Then, as new opportunities are added to the platform, or unpublished, the opportunity will be added only to the queues of those admins who are assigned/subscribed to that region.

*screencap*: https://cl.ly/75f605074b47

