### PR TITLE
redirect to sso logout after local logout

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -29,6 +29,8 @@ class HomeController < ApplicationController
       url="#{Rails.application.secrets.sso_url}login?service=#{service}"
     end
 
+    session[:service_signout_url] = url.gsub(/login/, 'logout')
+
     Rails.logger.info("SSO_URL: #{url}")
     redirect_to url
     #redirect_to session.delete(:last)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,4 +10,17 @@ class SessionsController < Devise::SessionsController
       redirect_to new_sso_user_session_path
     end
   end
+  
+  def destroy
+    url = if session[:service_signout_url]
+      session[:service_signout_url]
+    else
+      service = URI.encode("#{request.base_url}/users/service_braven", /[^\-_!~*'()a-zA-Z\d;?@&=+$,\[\]]/)
+      "#{Rails.application.secrets.sso_url}logout?service=#{service}"
+    end
+    
+    reset_session
+
+    redirect_to url
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get 'home/welcome'
   get 'health_check', to: 'home#health_check'
   get 'login', to: 'home#login'
+  post 'logout', to: 'home#logout'
   get 'sso/:id', to: 'home#sso', as: 'sso'
   get 'token/:id', to: 'token#show', as: 'token'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
   get 'home/welcome'
   get 'health_check', to: 'home#health_check'
   get 'login', to: 'home#login'
-  post 'logout', to: 'home#logout'
   get 'sso/:id', to: 'home#sso', as: 'sso'
   get 'token/:id', to: 'token#show', as: 'token'
 


### PR DESCRIPTION
This allows proper SSO logout in MCM. It does this in two parts:

* makes a note of which SSO service URL was used to login, and stores a modified version of this in the user's session. The URL is modified to point to the "logout" endpoint instead of the "login" endpoint.
* It redirects to the SSO logout url after logging the user out locally.