### PR TITLE
Add NYC to regions

### DIFF
--- a/config/regions.yml
+++ b/config/regions.yml
@@ -1,4 +1,5 @@
 - Bay
 - Newark
 - Chicago
+- NYC
 - Nationwide


### PR DESCRIPTION
Ticket: ZD-651

Context: Regions use this for the opportunities newsletter, and need to be able to submit opportunities for the NYC region.